### PR TITLE
GD-3642: Make slotName depth configurable for a9 requests

### DIFF
--- a/ad-tag/source/ts/ads/a9.ts
+++ b/ad-tag/source/ts/ads/a9.ts
@@ -228,9 +228,16 @@ export const a9RequestBids = (config: Moli.headerbidding.A9Config): RequestBidsS
                       )
                     : moliSlot.sizes;
 
+                  // The configured max slot depth in either the slot config or the global a9 config.
+                  const slotNameDepth = moliSlot.a9.slotNamePathDepth ?? config.slotNamePathDepth;
+
+                  const adUnitPathWithoutChildId = adUnitPath.removeChildId(moliSlot.adUnitPath);
+
                   return {
                     slotID: moliSlot.domId,
-                    slotName: adUnitPath.removeChildId(moliSlot.adUnitPath),
+                    slotName: slotNameDepth
+                      ? adUnitPath.withDepth(adUnitPathWithoutChildId, slotNameDepth)
+                      : adUnitPathWithoutChildId,
                     sizes: filterSupportedSizes(enabledSizes).filter(SizeConfigService.isFixedSize),
                     ...(config.enableFloorPrices && priceRule
                       ? // During the beta phase we need to be able to activate and deactivate floor prices

--- a/ad-tag/source/ts/ads/adUnitPath.test.ts
+++ b/ad-tag/source/ts/ads/adUnitPath.test.ts
@@ -1,7 +1,7 @@
 import { expect, use } from 'chai';
 import sinonChai from 'sinon-chai';
 
-import { removeChildId } from './adUnitPath';
+import { removeChildId, withDepth } from './adUnitPath';
 
 // setup sinon-chai
 use(sinonChai);
@@ -24,6 +24,23 @@ describe('ad unit path', () => {
         ['/1234567,1234,5678/Travel/Europe,Berlin', '/1234567/Travel/Europe,Berlin']
       ].forEach(([input, expected]) => {
         expect(removeChildId(input)).to.be.equals(expected);
+      });
+    });
+  });
+  describe('withDepth', () => {
+    it('should not change anything if the adUnit already has the same depth or is smaller', () => {
+      ['/1234567/Travel', '/1234567/Travel/Europe'].forEach(adUnitPath => {
+        expect(adUnitPath).to.be.equals(withDepth(adUnitPath, 3));
+      });
+    });
+
+    it('should shorten the adUnitPath', () => {
+      [
+        ['/1234567/Publisher/Slot', '/1234567/Publisher/Slot'],
+        ['/1234567/Publisher/Slot/Device', '/1234567/Publisher/Slot'],
+        ['/1234567/Publisher/Slot/Device/Category', '/1234567/Publisher/Slot']
+      ].forEach(([input, expected]) => {
+        expect(withDepth(input, 3)).to.be.equals(expected);
       });
     });
   });

--- a/ad-tag/source/ts/ads/adUnitPath.ts
+++ b/ad-tag/source/ts/ads/adUnitPath.ts
@@ -28,3 +28,18 @@ export const removeChildId = (adUnitPath: string): string => {
   const [parentNetworkId, ...childIds] = networkIds.split(',');
   return childIds.length === 0 ? adUnitPath : ['', parentNetworkId, ...rest].join('/');
 };
+
+/**
+ * We don't want to be the adUnitPath's in a9 as granular as they're in the google adManager.
+ * For this reason, we reduce the depth of the adUnitPath in this method.
+ *
+ * E.g. `shortenWithDepth('/1234567/Travel/Germany/Berlin', 3) will result in '/1234567/Travel/Germany'`
+ *
+ * @param adUnitPath The adUnitPath that should be shortened.
+ * @param depth The maximum depth of the adUnitPath.
+ */
+export const withDepth = (adUnitPath: string, depth: number): string => {
+  const adUnitPathSegments = adUnitPath.split('/');
+
+  return adUnitPathSegments.slice(0, depth + 1).join('/');
+};

--- a/ad-tag/source/ts/types/moli.ts
+++ b/ad-tag/source/ts/types/moli.ts
@@ -1292,6 +1292,11 @@ export namespace Moli {
       readonly sha256Email: string;
     }
 
+    /**
+     * The maximum depth of the adUnitPath for a9 bid requests.
+     */
+    export type A9SlotNamePathDepth = 3 | 4 | 5;
+
     export interface A9Config {
       /**
        * publisher ID
@@ -1336,6 +1341,11 @@ export namespace Moli {
        * Configure the Amazon _Publisher Audiences_ feature.
        */
       readonly publisherAudience?: A9PublisherAudienceConfig;
+
+      /**
+       * Configure the maximum depth for all slotName paths in a9 requests.
+       */
+      readonly slotNamePathDepth?: A9SlotNamePathDepth;
     }
 
     /**
@@ -1358,6 +1368,8 @@ export namespace Moli {
       readonly labelAny?: string[];
       /** Optional media type (default to display) */
       readonly mediaType?: 'display' | 'video';
+      /** Optional configuration of the maximum depth for the slotName path of this adSlot. (overrides the value in the global a9 config) */
+      readonly slotNamePathDepth?: A9SlotNamePathDepth;
     }
   }
 


### PR DESCRIPTION
The Amazon APS slotName represents the tag_id being sent to all partners in the bid request. We use the ad unit path without the MCM child networkID for this purpose as it's a unique and immutable identifier.

Changing the ad units would also mean changing the ad unit paths and thus changing the _tag_id_s for all our Amazon TAM partners. Some partners would need to placements others don't. In general we want to avoid any effort if there isn't a clear benefit.

**Solution**
A generic solution is to make the ad unit path depth configurable.

**Examples:**

`/1234/example.com/content_1/mobile/article`
With a depth of 4 the result is

`/1234/example.com/content_1/mobile`

With a depth of 6 the result is

`/1234/example.com/content_1/mobile/article`

**Configuration options**
- An optional global slotNamePathDepth in the A9Config object
- An optional override for the global config in the A9AdSlotConfig
- If no configuration is given the adUnitPath won't be changed.