### PR TITLE
GD-3678 Use existing adUnitPath or pubstack

### DIFF
--- a/ad-tag/source/ts/ads/prebid.ts
+++ b/ad-tag/source/ts/ads/prebid.ts
@@ -197,10 +197,13 @@ export const prebidPrepareRequestAds = (): PrepareRequestAdsStep =>
 
                 const pubstack: prebidjs.IPubstackConfig = {
                   ...prebidAdSlotConfig.adUnit.pubstack,
-                  adUnitPath: resolveAdUnitPath(moliSlot.adUnitPath, {
-                    ...context.config.targeting?.adUnitPathVariables,
-                    device: deviceLabel
-                  })
+                  adUnitPath: resolveAdUnitPath(
+                    prebidAdSlotConfig.adUnit.pubstack?.adUnitPath || moliSlot.adUnitPath,
+                    {
+                      ...context.config.targeting?.adUnitPathVariables,
+                      device: deviceLabel
+                    }
+                  )
                 };
 
                 return {


### PR DESCRIPTION
The pubstack `adUnitPath` can be further customed by adding "query parameters", which tells pubstack to use a custom dimension. This is feature is only possible if the ad tag reuses the predefined `adUnitPath` parameter and resolves it.

Ususally this is not needed though.