### PR TITLE
GD-3902 TheADEX module - allow empty targetings

### DIFF
--- a/modules/adex/index.test.ts
+++ b/modules/adex/index.test.ts
@@ -223,7 +223,7 @@ describe('The Adex DMP Module', () => {
     expect(jsDomWindow._adexc).to.be.undefined;
   });
 
-  it("shouldn't load the script if no adex data can be produced with the given mappings", async () => {
+  it('shouldn load the script if no adex data can be produced with the given mappings', async () => {
     const module = createAdexModule(true, '123', '456', [
       { key: 'subChannel', attribute: 'iab_cat', adexValueType: 'string' }
     ]);
@@ -234,7 +234,9 @@ describe('The Adex DMP Module', () => {
       prepareRequestAdsSteps: []
     };
 
-    const loadScriptStub = sandbox.stub(assetLoaderService, 'loadScript');
+    const loadScriptStub = sandbox
+      .stub(assetLoaderService, 'loadScript')
+      .returns(Promise.resolve());
 
     const { moliConfig } = initModule({ module, configPipeline });
 
@@ -245,8 +247,8 @@ describe('The Adex DMP Module', () => {
       )
     ).to.eventually.be.fulfilled;
 
-    expect(loadScriptStub).to.have.not.been.called;
-    expect(jsDomWindow._adexc).to.be.undefined;
+    expect(loadScriptStub).to.have.been.called;
+    expect(jsDomWindow._adexc).to.be.ok;
   });
 
   const consentSituations: Array<{ description: string; tcData: Partial<TCData> }> = [

--- a/modules/adex/index.ts
+++ b/modules/adex/index.ts
@@ -220,9 +220,8 @@ export class AdexModule implements IModule {
       })
       .filter(isNotNull);
 
-    if (adexKeyValues.length === 0) {
-      context.logger.warn('Adex DMP', 'no Adex key/values produced, aborting');
-      return Promise.resolve();
+    if (mappingDefinitions.length === 0 && adexKeyValues.length === 0) {
+      context.logger.warn('Adex DMP', 'no Adex key/values produced');
     }
 
     this.window._adexc = this.window._adexc || [];


### PR DESCRIPTION
Empty `mappingDefinitions` should still call the script

```js
moli.registerModule(
  new AdexModule(
    {
      mappingDefinitions: [],
      adexCustomerId: '111',
      adexTagId: '2222',
      spaMode: false // non-spa web project
    },
    window
  )
);
```