### PR TITLE
GD-3920 Moli AdReload doesn't resolve ad unit path variables

### DIFF
--- a/ad-tag/source/ts/ads/moli.test.ts
+++ b/ad-tag/source/ts/ads/moli.test.ts
@@ -209,18 +209,19 @@ describe('moli', () => {
 
     const initSpy = sandbox.spy(fakeModule, 'init');
 
-    it('should init modules in the configure call', () => {
+    it('should init modules in the requestAds call', async () => {
       const adTag = createMoliTag(jsDomWindow);
       const config = newEmptyConfig(defaultSlots);
 
       adTag.registerModule(fakeModule);
       adTag.configure(config);
+      await adTag.requestAds();
 
       expect(initSpy).to.have.been.calledOnce;
       expect(initSpy).to.have.been.calledWithMatch(config, adTag.getAssetLoaderService());
     });
 
-    it('should init modules and use the changed config', () => {
+    it('should init modules and use the changed config', async () => {
       const adTag = createMoliTag(jsDomWindow);
       const config = newEmptyConfig(defaultSlots);
       const targeting = {
@@ -238,13 +239,14 @@ describe('moli', () => {
 
       adTag.registerModule(configChangingModule);
       adTag.configure(config);
+      const state = await adTag.requestAds();
 
       expect(configChangingInitSpy).to.have.been.calledOnce;
       expect(configChangingInitSpy).to.have.been.calledWithMatch(
         config,
         adTag.getAssetLoaderService()
       );
-      expect(adTag.getState()).to.be.eq('configured');
+      expect(adTag.getState()).to.be.eq(state.state);
       const newConfig = adTag.getConfig()!;
       expect(newConfig).to.be.ok;
 

--- a/ad-tag/source/ts/ads/moli.ts
+++ b/ad-tag/source/ts/ads/moli.ts
@@ -330,18 +330,6 @@ export const createMoliTag = (window: Window): Moli.MoliTag => {
           setEnvironmentOverrideInStorage(envOverride.environment, window.sessionStorage);
         }
 
-        // initialize modules with the config from the ad tag. There is no external configuration support for modules.
-        // the config will be altered by this call
-        modules.forEach(module => {
-          const log = getLogger(config, window);
-          log.debug(
-            'MoliGlobal',
-            `initialize ${module.moduleType} module ${module.name}`,
-            module.config()
-          );
-          module.init(config, assetLoaderService, adService.getAdPipeline);
-        });
-
         state = {
           state: 'configured',
           configFromAdTag: config,
@@ -375,6 +363,7 @@ export const createMoliTag = (window: Window): Moli.MoliTag => {
             },
             logger: state.logger || config.logger
           },
+          modules: modules,
           moduleMeta: modules.map(metaFromModule),
           hooks: state.hooks,
           isSinglePageApp: state.isSinglePageApp,
@@ -456,6 +445,19 @@ export const createMoliTag = (window: Window): Moli.MoliTag => {
       case 'configured': {
         setABtestTargeting();
         const config = state.config;
+
+        // initialize modules with the config from the ad tag.
+        // the config will be altered by this call
+        const modules = state.modules;
+        modules.forEach(module => {
+          const log = getLogger(config, window);
+          log.debug(
+            'MoliGlobal',
+            `initialize ${module.moduleType} module ${module.name}`,
+            module.config()
+          );
+          module.init(config, assetLoaderService, adService.getAdPipeline);
+        });
 
         // call the configured hooks
         if (state.hooks && state.hooks.beforeRequestAds) {

--- a/ad-tag/source/ts/types/moli.ts
+++ b/ad-tag/source/ts/types/moli.ts
@@ -514,6 +514,11 @@ export namespace Moli {
       config: Moli.MoliConfig;
 
       /**
+       * Contains the list of modules that need to be initialized
+       */
+      modules: IModule[];
+
+      /**
        * Add hooks on specific state changes.
        */
       hooks: IHooks;

--- a/examples/publisher/demo/index.hbs
+++ b/examples/publisher/demo/index.hbs
@@ -78,6 +78,9 @@
     moliAdTag.setTargeting('isAdultContent', 'false');
     // allows targeting for user agents
     moliAdTag.setTargeting('supportedUserAgent', 'true');
+
+    // resolve paths
+    moliAdTag.setAdUnitPathVariables({ category: 'seo' });
   });
 
   // hooks

--- a/examples/publisher/source/ts/ad-tag.ts
+++ b/examples/publisher/source/ts/ad-tag.ts
@@ -90,7 +90,9 @@ moli.registerModule(
       ],
       includeOrderIds: [2690210604, 2690917340, 2674536678],
       excludeOrderIds: [],
-      includeAdvertiserIds: [4693931408 /* AppNexus */, 4868030566]
+      includeAdvertiserIds: [
+        4693931408 /* AppNexus */, 4868030566, 4858511198 /* gutefrage-intern */
+      ]
     },
     window
   )

--- a/examples/publisher/source/ts/configuration.ts
+++ b/examples/publisher/source/ts/configuration.ts
@@ -132,7 +132,7 @@ export const adConfiguration: Moli.MoliConfig = {
       domId: 'eager-loading-adslot',
       position: 'in-page',
       behaviour: { loaded: 'eager' },
-      adUnitPath: '/55155651/test-ad-unit',
+      adUnitPath: '/55155651/test-ad-unit/{device}-{category}',
       sizes: ['fluid', [300, 250], [300, 600], [970, 250]],
       passbackSupport: true,
       sizeConfig: [
@@ -259,8 +259,8 @@ export const adConfiguration: Moli.MoliConfig = {
               appNexusOutstream('13232385', context.floorPrice)
             ]
           }
-        }
-      } ,
+        };
+      },
       sizeConfig: [
         {
           mediaQuery: '(min-width: 768px)',


### PR DESCRIPTION
Initialize modules in first requestAds call