### PR TITLE
GD-4187 Add resolveAdUnitPath API

### DIFF
--- a/ad-tag/source/ts/ads/moli.test.ts
+++ b/ad-tag/source/ts/ads/moli.test.ts
@@ -524,6 +524,36 @@ describe('moli', () => {
         });
     });
   });
+  describe('resolveAdUnitPath', () => {
+    describe('configure state', () => {
+      it('should resolve without variables being set', () => {
+        const adTag = createMoliTag(jsDomWindow);
+        expect(adTag.resolveAdUnitPath('/foo/bar')).to.be.equals('/foo/bar');
+      });
+      it('should resolve with variables being set', () => {
+        const adTag = createMoliTag(jsDomWindow);
+        adTag.setAdUnitPathVariables({ foo: 'value' });
+        expect(adTag.resolveAdUnitPath('/foo/{foo}')).to.be.equals('/foo/value');
+      });
+      it('should throw an error when using undefined variables', () => {
+        const adTag = createMoliTag(jsDomWindow);
+        expect(() => adTag.resolveAdUnitPath('/foo/{foo}')).to.throw(
+          Error,
+          'path variable "foo" is not defined'
+        );
+      });
+    });
+
+    describe('all other states', () => {
+      it('should resolve from the config.targeting.adUnitPathVariables', () => {
+        const adTag = createMoliTag(jsDomWindow);
+        adTag.setAdUnitPathVariables({ foo: 'value' });
+        adTag.configure(defaultConfig);
+
+        expect(adTag.resolveAdUnitPath('/foo/{foo}')).to.be.equals('/foo/value');
+      });
+    });
+  });
 
   describe('setTargeting()', () => {
     it('should add key-values to the config', () => {

--- a/ad-tag/source/ts/ads/moli.ts
+++ b/ad-tag/source/ts/ads/moli.ts
@@ -18,6 +18,7 @@ import {
   setEnvironmentOverrideInStorage
 } from '../util/environmentOverride';
 import { packageJson } from '../gen/packageJson';
+import * as adUnitPath from './adUnitPath';
 
 export const createMoliTag = (window: Window): Moli.MoliTag => {
   // Creating the actual tag requires exactly one AdService instance
@@ -153,6 +154,30 @@ export const createMoliTag = (window: Window): Moli.MoliTag => {
         break;
       }
     }
+  }
+
+  function getAdUnitPathVariables(): adUnitPath.AdUnitPathVariables | undefined {
+    switch (state.state) {
+      case 'configurable':
+        return state.adUnitPathVariables;
+      case 'configured':
+      case 'requestAds':
+      case 'spa-requestAds':
+      case 'spa-finished':
+      case 'finished':
+      case 'error':
+        return state.config.targeting?.adUnitPathVariables;
+    }
+  }
+
+  function resolveAdUnitPath(
+    adUnitPathParam: string,
+    options?: Moli.ResolveAdUnitPathOptions
+  ): string {
+    const opts = options || {};
+    const removeNetworkChildId: boolean = opts.removeNetworkChildId || false;
+    const resolvedPath = adUnitPath.resolveAdUnitPath(adUnitPathParam, getAdUnitPathVariables());
+    return removeNetworkChildId ? adUnitPath.removeChildId(resolvedPath) : resolvedPath;
   }
 
   function setLogger(logger: Moli.MoliLogger): void {
@@ -770,6 +795,7 @@ export const createMoliTag = (window: Window): Moli.MoliTag => {
     setLogger: setLogger,
     setSampleRate: setSampleRate,
     setAdUnitPathVariables: setAdUnitPathVariables,
+    resolveAdUnitPath: resolveAdUnitPath,
     addReporter: addReporter,
     beforeRequestAds: beforeRequestAds,
     afterRequestAds: afterRequestAds,

--- a/ad-tag/source/ts/types/moli.ts
+++ b/ad-tag/source/ts/types/moli.ts
@@ -101,6 +101,15 @@ export namespace Moli {
     setAdUnitPathVariables(variables: AdUnitPathVariables): void;
 
     /**
+     * Resolves an ad unit path by replacing the ad unit path variables.
+     * Optionally the networkChildId can be removed.
+     *
+     * @param adUnitPath the ad unit path that may contain variables in the form of {variable name}
+     * @param options configure resolving behaviour
+     */
+    resolveAdUnitPath(adUnitPath: string, options?: ResolveAdUnitPathOptions): string;
+
+    /**
      * Set a custom logger that should be used for logging.
      *
      * @param logger
@@ -771,6 +780,29 @@ export namespace Moli {
 
   export type AdUnitPathVariables = {
     [key: string]: string;
+  };
+
+  /**
+   * Parameters to configure the resolve function
+   */
+  export type ResolveAdUnitPathOptions = {
+    /**
+     * If set to true then the networkChildId will be removed from the ad unit path.
+     * E.g.
+     *
+     * ```
+     * /123,456/content_1`
+     * ```
+     *
+     *
+     *
+     * ```
+     * /123/content_1`
+     * ```
+     *
+     * default: `false`
+     */
+    readonly removeNetworkChildId?: boolean;
   };
 
   export interface Targeting {


### PR DESCRIPTION
Allows for resolving the ad unit path by external systems

```js
moli.resolveAdUnitPath('/123,345/foo/bar/{device}/{category}');
moli.resolveAdUnitPath('/123,455/foo/bar/{device}/{category}', { removeNetworkChildId: true });
```