### PR TITLE
Revert "Use new js operator for accessing undefined properties"

### DIFF
--- a/ad-tag/source/ts/util/logging.ts
+++ b/ad-tag/source/ts/util/logging.ts
@@ -155,7 +155,7 @@ export function getDefaultLogger(): Moli.MoliLogger {
 export function getLogger(config: Moli.MoliConfig | null, window: Window): Moli.MoliLogger {
   if (getMoliDebugParameter(window)) {
     return getDefaultLogger();
-  } else if (config?.logger) {
+  } else if (config && config.logger) {
     return config.logger;
   } else {
     return getNoopLogger();


### PR DESCRIPTION
This reverts commit 1f821907da662fd8df82f42abaa51b9dc02ab111.