### PR TITLE
GD-4659 Add labelNone targeting option for sizeConfig

### DIFF
--- a/ad-tag/source/ts/ads/sizeConfigService.test.ts
+++ b/ad-tag/source/ts/ads/sizeConfigService.test.ts
@@ -158,11 +158,12 @@ describe('SizeConfigService', () => {
 
   describe('additional label filtering', () => {
     const sizes: DfpSlotSize[] = [[300, 250], 'fluid'];
-    const newSizeConfigEntry = (labelAll?: string[]): SizeConfigEntry => {
+    const newSizeConfigEntry = (labelAll?: string[], labelNone?: string[]): SizeConfigEntry => {
       return {
         sizesSupported: sizes,
         mediaQuery: 'min-width: 300px',
-        labelAll: labelAll
+        labelAll,
+        labelNone
       };
     };
 
@@ -171,8 +172,13 @@ describe('SizeConfigService', () => {
       expect(sizeConfigService.filterSupportedSizes(sizes)).to.deep.equal(sizes);
     });
 
-    it('should accept supported sizes if all labels is empty', () => {
+    it('should accept supported sizes if labelAll is empty', () => {
       const sizeConfigService = newSizeConfigService([newSizeConfigEntry([])]);
+      expect(sizeConfigService.filterSupportedSizes(sizes)).to.deep.equal(sizes);
+    });
+
+    it('should accept supported sizes if labelAll and labelNone is empty', () => {
+      const sizeConfigService = newSizeConfigService([newSizeConfigEntry([], [])]);
       expect(sizeConfigService.filterSupportedSizes(sizes)).to.deep.equal(sizes);
     });
 
@@ -182,9 +188,36 @@ describe('SizeConfigService', () => {
       expect(sizeConfigService.filterSupportedSizes(sizes)).to.deep.equal(sizes);
     });
 
+    it('should accept supported sizes if all labels are included in the supported labels and labelsNone is empty', () => {
+      const labels = ['page-x'];
+      const sizeConfigService = newSizeConfigService([newSizeConfigEntry(labels, [])], labels);
+      expect(sizeConfigService.filterSupportedSizes(sizes)).to.deep.equal(sizes);
+    });
+
+    it('should accept supported sizes if all labels are not set and labelsNone has no intersection with supported labels', () => {
+      const labels = ['page-x'];
+      const sizeConfigService = newSizeConfigService(
+        [newSizeConfigEntry(undefined, ['foo'])],
+        labels
+      );
+      expect(sizeConfigService.filterSupportedSizes(sizes)).to.deep.equal(sizes);
+    });
+
+    it('should accept supported sizes if labelAll and labelNone conditions are met', () => {
+      const labels = ['page-x'];
+      const sizeConfigService = newSizeConfigService([newSizeConfigEntry(labels, ['foo'])], labels);
+      expect(sizeConfigService.filterSupportedSizes(sizes)).to.deep.equal(sizes);
+    });
+
     it('should filter supported sizes if not all labels are included in the supported labels', () => {
       const labels = ['page-x'];
       const sizeConfigService = newSizeConfigService([newSizeConfigEntry(labels)], []);
+      expect(sizeConfigService.filterSupportedSizes(sizes)).to.deep.equal([]);
+    });
+
+    it('should filter supported sizes if not all labels are included in the supported labels and labelNone is empty', () => {
+      const labels = ['page-x'];
+      const sizeConfigService = newSizeConfigService([newSizeConfigEntry(labels, [])], []);
       expect(sizeConfigService.filterSupportedSizes(sizes)).to.deep.equal([]);
     });
 

--- a/ad-tag/source/ts/ads/sizeConfigService.ts
+++ b/ad-tag/source/ts/ads/sizeConfigService.ts
@@ -51,10 +51,7 @@ export class SizeConfigService {
               // media query must match
               window.matchMedia(conf.mediaQuery).matches &&
               // if labelAll is defined, all labels must be part of the supportedLabels array
-              (!conf.labelAll ||
-                conf.labelAll.every(label =>
-                  supportedLabels.some(supportedLabel => supportedLabel === label)
-                ))
+              this.areLabelsMatching(conf, supportedLabels)
           )
         : [];
 
@@ -111,5 +108,21 @@ export class SizeConfigService {
             }
           })
         );
+  };
+
+  private areLabelsMatching = (conf: Moli.SizeConfigEntry, supportedLabels: string[]): boolean => {
+    return (
+      // either labelAll is not set or _all_ labels must be present
+      (!conf.labelAll ||
+        conf.labelAll.every(label =>
+          supportedLabels.some(supportedLabel => supportedLabel === label)
+        )) &&
+      // and either labelNone is not set or none of should be present
+      (!conf.labelNone ||
+        // false as soon as one of the supported labels is part of the labelNone set
+        !conf.labelNone.some(label =>
+          supportedLabels.some(supportedLabel => supportedLabel === label)
+        ))
+    );
   };
 }

--- a/ad-tag/source/ts/types/moli.ts
+++ b/ad-tag/source/ts/types/moli.ts
@@ -842,17 +842,38 @@ export namespace Moli {
    * ```typescript
    * [{
    *   // mobile devices support a medium rectangle
-   *   mediaQuery: (max-width: 767px)
+   *   mediaQuery: (max-width: 767px),
    *   sizesSupported: [[300,250]]
    * }, {
    *   // desktop sidebar supports medium rectangle
-   *   mediaQuery: (min-width: 768px)
+   *   mediaQuery: (min-width: 768px),
    *   sizesSupported: [[300,250]]
    * }]
    * ```
    *
    * This result in `[[300,250]]` being always supported, which may not be something you want.
    *
+   * ### Using labels
+   *
+   * If you have the same slot on different page types with a different layout you can differentation size configs
+   * via two properites
+   *
+   * - `labelAll` - all labels need to be present if this size config should be applied
+   * - `labelNone` - none of the labels must be present if this size config should be applied
+   *
+   * ```typescript
+   * [{
+   *   // mobile devices support a medium rectangle
+   *   mediaQuery: (max-width: 767px),
+   *   labelAll: ['homepage'],
+   *   sizesSupported: [[728,90]]
+   * }, {
+   *   // desktop sidebar supports medium rectangle
+   *   mediaQuery: (min-width: 768px)
+   *   labelNone: ['homepage']
+   *   sizesSupported: [[728,90], [900,250]]
+   * }]
+   * ```
    *
    * ## Prebid API
    *
@@ -872,6 +893,9 @@ export namespace Moli {
 
     /** optional array of labels. All labels must be present if the sizes should be applied */
     readonly labelAll?: string[];
+
+    /** optional array of labels. All labels must **not** be present if the sizes should be applied */
+    readonly labelNone?: string[];
 
     /** static sizes that are support if the media query matches */
     readonly sizesSupported: DfpSlotSize[];


### PR DESCRIPTION
Support a `labelNone` array for `sizeConfigs` to allow easier separation between page types.

Example:

```typescript
const sizeConfig: Moli.SizeConfigEntry[] = [
  { 
     mediaQuery: '...',
     labelAll: [ 'homepage' ],
     sizesSupport: [ /* ... */]
   },
  { 
     mediaQuery: '...',
     labelNone: [ 'homepage' ],
     sizesSupport: [ /* ... */]
   }
]
```