### PR TITLE
GD-4659 make labels generic which allows to narrow down the labels type

### DIFF
--- a/ad-tag/source/ts/types/moli.ts
+++ b/ad-tag/source/ts/types/moli.ts
@@ -887,15 +887,15 @@ export namespace Moli {
    * @see [Size Mapping](https://prebid.org/dev-docs/examples/size-mapping.html)
    * @see [requestBids with labels](https://prebid.org/dev-docs/publisher-api-reference.html#module_pbjs.requestBids)
    */
-  export interface SizeConfigEntry {
+  export interface SizeConfigEntry<Label = string> {
     /** media query that must match if the sizes are applicable */
     readonly mediaQuery: string;
 
     /** optional array of labels. All labels must be present if the sizes should be applied */
-    readonly labelAll?: string[];
+    readonly labelAll?: Label[];
 
     /** optional array of labels. All labels must **not** be present if the sizes should be applied */
-    readonly labelNone?: string[];
+    readonly labelNone?: Label[];
 
     /** static sizes that are support if the media query matches */
     readonly sizesSupported: DfpSlotSize[];


### PR DESCRIPTION
Allows to improve the typings for labels on size configs.

Example

```typescript
type Label = 'homepage' | 'article' | 'listing';

// compiles
const sizeConfig1: Moli.SizeConfigEntry<Label>[] = [
  {
    mediaQuery: '(min-width: 767px)',
    labelAll: ['homepage']
    sizesSupported: [  [800, 250], [728, 90]  ]
  },
];

// error
const sizeConfig2: Moli.SizeConfigEntry<Label>[] = [
  {
    mediaQuery: '(min-width: 767px)',
    labelAll: ['Homepage']
    sizesSupported: [  [800, 250], [728, 90]  ]
  },
];
```