### PR TITLE
GD-4686 Implement sticky footer ads module

### DIFF
--- a/ad-tag/source/ts/stubs/googletagStubs.ts
+++ b/ad-tag/source/ts/stubs/googletagStubs.ts
@@ -35,6 +35,9 @@ const createPubAdsServiceStub = (): googletag.IPubAdsService => {
     ): googletag.IPubAdsService => {
       return stub;
     },
+    removeEventListener: (_eventType: string, _listener: (event: any) => void) => {
+      return false;
+    },
     setPrivacySettings: (_options: googletag.IPrivacySettingsConfig): googletag.IPubAdsService => {
       return stub;
     },
@@ -55,6 +58,9 @@ export const contentServiceStub: googletag.IContentService = {
     _listener: (event: any) => void
   ): googletag.IContentService => {
     return contentServiceStub;
+  },
+  removeEventListener: (_eventType: string, _listener: (event: any) => void) => {
+    return false;
   },
   setContent(slot: googletag.IAdSlot, content: string): void {
     return;
@@ -86,6 +92,9 @@ export const googleAdSlotStub = (adUnitPath: string, slotId: string): googletag.
     },
     addService: (_service: googletag.IService<any>): void => {
       return;
+    },
+    getResponseInformation: (): googletag.IResponseInformation | null => {
+      return null;
     }
   };
   return stub;

--- a/ad-tag/source/ts/types/googletag.ts
+++ b/ad-tag/source/ts/types/googletag.ts
@@ -87,6 +87,60 @@ export namespace googletag {
     ): T;
 
     /**
+     * @see https://developers.google.com/publisher-tag/reference#googletag.Service_removeEventListener
+     * @return Whether existing event listener was removed.
+     */
+    removeEventListener(
+      eventType: 'slotRenderEnded',
+      listener: (event: events.ISlotRenderEndedEvent) => void
+    ): boolean;
+
+    /**
+     * @see https://developers.google.com/publisher-tag/reference#googletag.Service_removeEventListener
+     * @return Whether existing event listener was removed.
+     */
+    removeEventListener(
+      eventType: 'impressionViewable',
+      listener: (event: events.IImpressionViewableEvent) => void
+    ): boolean;
+
+    /**
+     * @see https://developers.google.com/publisher-tag/reference#googletag.Service_removeEventListener
+     * @return Whether existing event listener was removed.
+     */
+    removeEventListener(
+      eventType: 'slotOnload',
+      listener: (event: events.ISlotOnloadEvent) => void
+    ): boolean;
+
+    /**
+     * @see https://developers.google.com/publisher-tag/reference#googletag.Service_removeEventListener
+     * @return Whether existing event listener was removed.
+     */
+    removeEventListener(
+      eventType: 'slotRequested',
+      listener: (event: events.ISlotRequestedEvent) => void
+    ): boolean;
+
+    /**
+     * @see https://developers.google.com/publisher-tag/reference#googletag.Service_removeEventListener
+     * @return Whether existing event listener was removed.
+     */
+    removeEventListener(
+      eventType: 'slotResponseReceived',
+      listener: (event: events.ISlotResponseReceived) => void
+    ): boolean;
+
+    /**
+     * @see https://developers.google.com/publisher-tag/reference#googletag.Service_removeEventListener
+     * @return Whether existing event listener was removed.
+     */
+    removeEventListener(
+      eventType: 'slotVisibilityChanged',
+      listener: (event: events.ISlotVisibilityChangedEvent) => void
+    ): boolean;
+
+    /**
      * Get the list of slots associated with this service.
      */
     getSlots(): Array<IAdSlot>;
@@ -484,6 +538,49 @@ export namespace googletag {
      * @see https://developers.google.com/doubleclick-gpt/reference#googletag.Slot_clearTargeting
      */
     clearTargeting(key?: string): void;
+
+    /**
+     * Returns the ad response information. This is based on the last ad response for the slot.
+     * If this is called when the slot has no ad
+     *
+     * @see https://developers.google.com/publisher-tag/reference#googletag.Slot_getResponseInformation
+     * @return The latest ad response information, or null if the slot has no ad.
+     */
+    getResponseInformation(): null | IResponseInformation;
+  }
+
+  export interface IResponseInformation {
+    /**
+     * Advertiser ID of the rendered ad. Value is null for empty slots, backfill ads or creatives rendered by services other than pubads service.
+     *
+     * Viewable in ad manager: https://admanager.google.com/33559401#admin/companyDetail/id=[advertiserId]
+     */
+    readonly advertiserId: null | number;
+
+    /**
+     * Campaign ID (Order ID) of the rendered ad. Value is null for empty slots, backfill ads or creatives rendered by services other than pubads service.
+     *
+     * Viewable in ad manager: https://admanager.google.com/33559401#delivery/OrderDetail/orderId=[campaignId]
+     */
+    readonly campaignId?: number;
+
+    /**
+     * Line item ID of the rendered reservation ad. Value is null for empty slots, backfill ads or creatives rendered
+     * by services other than pubads service.
+     *
+     * Viewable in ad manager: https://admanager.google.com/33559401#delivery/LineItemDetail/orderId=[campaignId]&lineItemId=[lineItemId}
+     */
+    readonly lineItemId?: number;
+
+    /**
+     * Creative ID of the rendered reservation ad. Value is null for empty slots, backfill ads or creatives rendered by services other than pubads service.
+     */
+    readonly creativeId?: number;
+
+    /**
+     * Creative template ID if the creative is based upon a template
+     */
+    readonly creativeTemplateId: null | number;
   }
 
   /**

--- a/ad-tag/source/ts/types/module.ts
+++ b/ad-tag/source/ts/types/module.ts
@@ -11,7 +11,8 @@ export type ModuleType =
   | 'policy'
   | 'identity'
   | 'dmp'
-  | 'yield';
+  | 'yield'
+  | 'creatives';
 
 export interface IModule {
   readonly name: string;

--- a/examples/publisher/demo/index.hbs
+++ b/examples/publisher/demo/index.hbs
@@ -35,6 +35,110 @@
       margin-top: 1rem;
     }
   </style>
+
+  <!-- mobile sticky ad -->
+  <style>
+    .h5-sticky-ad {
+      background-color: #f3f3f3;
+      border: none;
+      bottom: 0;
+      box-shadow: 0 -1px 1px 0 rgba(0, 0, 0, 0.2);
+      height: 59px;
+      left: 0;
+      padding: 5px;
+      position: fixed;
+      text-align: center;
+      width: 100%;
+      z-index: 900; /* set this to a value that enables the sticky ad to overlap any other elements on the page. */
+    }
+
+    .h5-sticky-ad-close {
+      background-color: #f3f3f3;
+      background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg width='13' height='13' viewBox='341 8 13 13' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill='%234F4F4F' d='M354 9.31L352.69 8l-5.19 5.19L342.31 8 341 9.31l5.19 5.19-5.19 5.19 1.31 1.31 5.19-5.19 5.19 5.19 1.31-1.31-5.19-5.19z' fill-rule='evenodd'/%3E%3C/svg%3E");
+      background-position: 9px;
+      background-repeat: no-repeat;
+      background-size: 13px 13px;
+      border: none;
+      border-top-left-radius: 12px;
+      box-shadow: 0 -1px 1px 0 rgba(0, 0, 0, 0.2);
+      height: 28px;
+      padding: 6px;
+      position: absolute;
+      right: 0;
+      top: -28px;
+      width: 28px;
+    }
+
+    .h5-sticky-ad-close::before {
+      bottom: 0;
+      content: "";
+      left: -20px;
+      position: absolute;
+      right: 0;
+      top: -20px;
+    }
+
+    .u-visible-desktop {
+      display: none;
+    }
+
+    @media (min-width: 768px) {
+      .u-hidden-desktop {
+        display: none;
+      }
+
+      .u-visible-desktop {
+        display: block;
+      }
+    }
+  </style>
+
+  <!-- floor ad -->
+  <style>
+    .h5-footer-ad-container {
+      bottom: 0;
+      margin-left: auto;
+      margin-right: auto;
+      max-width: 970px;
+      overflow: visible;
+      position: fixed;
+      left: 50%;
+      transform: translate(-50%, 0);
+      z-index: 900; /* set this to a value that enables the footer ad to overlap any other elements on the page. */
+    }
+
+    .h5-footer-ad-close {
+      align-items: center;
+      appearance: none;
+      background-color: #cbcdce;
+      border: 2px solid #222223;
+      border-radius: 12px 12px 0 0;
+      color: #222223;
+      display: flex;
+      height: 24px;
+      justify-content: center;
+      position: absolute;
+      right: 0;
+      top: -24px;
+      width: 60px;
+    }
+    .h5-footer-ad-close:hover {
+      background-color: white;
+    }
+
+    .h5-footer-ad-close::after {
+      content: "×";
+      display: inline-block;
+    }
+
+    .is-shifted-bottom {
+      margin-bottom: -70px;
+    }
+
+    .is-shifted-bottom:hover {
+      margin-bottom: 0;
+    }
+  </style>
 </head>
 
 
@@ -137,10 +241,13 @@
 
     <h3>Moli Console</h3>
     <p>You can get more details by opening the moli console.</p>
-    <button class="btn btn-success" onclick="window.moli.openConsole()">Open Moli Console</button>
-    <a class="btn btn-secondary" href="?moliDebug=true">enable ad tag console logs</a>
-    <a class="btn btn-secondary" href="?pbjs_debug=true">enable prebid console logs</a>
-    <a class="btn btn-secondary" href="?moliEnv=test">enable test mode</a>
+    <div class="d-flex flex-wrap">
+      <button class="btn btn-success flex-fill mr-3 mb-3" onclick="window.moli.openConsole()">Open Moli Console
+      </button>
+      <a class="btn btn-outline-primary flex-fill mr-3 mb-3" href="?moliDebug=true">enable ad tag console logs</a>
+      <a class="btn btn-primary flex-fill mr-3 mb-3" href="?pbjs_debug=true">enable prebid console logs</a>
+      <a class="btn btn-info flex-fill mr-3 mb-3" href="?moliEnv=test">enable test mode</a>
+    </div>
 
     <p>Or if you are a developer, type this into the javascript console:</p>
     <pre><code class="html hljs xml">moli.openConsole()</code></pre>
@@ -243,8 +350,22 @@
     </div>
   </div>
 
-
 </div>
+<!-- mobile sticky ad -->
+<div class="h5-sticky-ad u-hidden-desktop" data-ref="sticky-ad">
+  <div id="ad-mobile-sticky" class="h5-sticky-ad-container"></div>
+  <button
+    class="h5-sticky-ad-close"
+    data-ref="sticky-ad-close"
+    aria-label="Anzeige entfernen"
+  ></button>
+</div>
+
+<!-- desktop floorad -->
+<div data-ref="h5-footer-ad-container">
+  <div id="ad-floorad"></div>
+</div>
+
 <!-- update the [[domain]] variable in the integration example -->
 <script>
   const code = document.getElementById('integration-code');

--- a/examples/publisher/source/ts/ad-tag.ts
+++ b/examples/publisher/source/ts/ad-tag.ts
@@ -27,6 +27,7 @@ import { Skin } from '@highfivve/module-generic-skin';
 import { AdReload } from '@highfivve/module-moli-ad-reload';
 import { YieldOptimization } from '@highfivve/module-yield-optimization';
 import { adConfiguration } from './configuration';
+import { StickyFooterAds } from '@highfivve/module-sticky-footer-ads';
 
 prebid.processQueue();
 
@@ -129,6 +130,15 @@ moli.registerModule(
     },
     window
   )
+);
+
+// footer ads
+moli.registerModule(
+  new StickyFooterAds({
+    mobileStickyDomId: 'ad-mobile-sticky',
+    desktopFloorAdDomId: 'ad-floorad',
+    disallowedAdvertiserIds: []
+  })
 );
 
 // init moli

--- a/examples/publisher/source/ts/configuration.ts
+++ b/examples/publisher/source/ts/configuration.ts
@@ -132,16 +132,68 @@ export const adConfiguration: Moli.MoliConfig = {
   },
   slots: [
     {
+      domId: 'ad-mobile-sticky',
+      adUnitPath: '/55155651/mobile-sticky/{device}-{category}',
+      position: 'in-page',
+      behaviour: { loaded: 'eager' },
+      labelAll: ['mobile'],
+      sizes: ['fluid', [300, 50], [320, 50]],
+      sizeConfig: [
+        {
+          mediaQuery: '(max-width: 767px)',
+          sizesSupported: ['fluid', [300, 50], [320, 50]]
+        }
+      ]
+    },
+    {
+      domId: 'ad-floorad',
+      adUnitPath: '/55155651/floorad/{device}-{category}',
+      position: 'in-page',
+      behaviour: { loaded: 'eager' },
+      labelAll: ['desktop'],
+      sizes: [
+        [728, 90],
+        [800, 250],
+        [900, 250],
+        [970, 250]
+      ],
+      sizeConfig: [
+        {
+          mediaQuery: '(min-width: 767px)',
+          sizesSupported: [[728, 90]]
+        },
+        {
+          mediaQuery: '(min-width: 800px)',
+          sizesSupported: [[800, 250]]
+        },
+        {
+          mediaQuery: '(min-width: 900px)',
+          sizesSupported: [[900, 250]]
+        },
+        {
+          mediaQuery: '(min-width: 970px)',
+          sizesSupported: [[970, 250]]
+        }
+      ]
+    },
+    {
       domId: 'eager-loading-adslot',
       position: 'in-page',
       behaviour: { loaded: 'eager' },
       adUnitPath: '/55155651/test-ad-unit/{device}-{category}',
-      sizes: ['fluid', [300, 250], [300, 600], [970, 250]],
-      passbackSupport: true,
+      sizes: ['fluid', [300, 250], [300, 600], [728, 90], [970, 250]],
       sizeConfig: [
         {
-          mediaQuery: '(min-width: 0px)',
-          sizesSupported: ['fluid', [300, 250], [300, 600], [970, 250]]
+          mediaQuery: '(max-width: 767px)',
+          sizesSupported: ['fluid', [300, 250], [300, 600]]
+        },
+        {
+          mediaQuery: '(min-width: 768px)',
+          sizesSupported: ['fluid', [728, 90]]
+        },
+        {
+          mediaQuery: '(min-width: 970px)',
+          sizesSupported: ['fluid', [970, 250]]
         }
       ]
     },
@@ -172,7 +224,6 @@ export const adConfiguration: Moli.MoliConfig = {
       },
       adUnitPath: '/55155651/test-ad-unit',
       sizes: ['fluid', [300, 250], [300, 600], [970, 250]],
-      passbackSupport: true,
       sizeConfig: [
         {
           mediaQuery: '(min-width: 0px)',
@@ -185,7 +236,6 @@ export const adConfiguration: Moli.MoliConfig = {
       domId: 'prebid-adslot',
       behaviour: { loaded: 'eager', bucket: 'ONE' },
       adUnitPath: '/55155651/outstream_test',
-      passbackSupport: true,
       sizes: [
         [605, 165],
         [605, 340],
@@ -305,7 +355,6 @@ export const adConfiguration: Moli.MoliConfig = {
           sizesSupported: ['fluid', [300, 250], [300, 600], [970, 250]]
         }
       ],
-      passbackSupport: true,
       prebid: context => {
         return {
           adUnit: {

--- a/modules/sticky-footer-ads/.eslintrc.js
+++ b/modules/sticky-footer-ads/.eslintrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+  extends: ['../../.eslintrc.js']
+};

--- a/modules/sticky-footer-ads/index.ts
+++ b/modules/sticky-footer-ads/index.ts
@@ -1,0 +1,107 @@
+/**
+ * # Sticky Footer Ads
+ *
+ * Out of page formats for mobile and desktop that are sticky at the bottom of the page.
+ * This is similar to the [Anchor Ads](https://developers.google.com/publisher-tag/samples/display-anchor-ad) provided
+ * by Google Ad Manager.
+ *
+ * ## Integration
+ *
+ * In your `index.ts` import and register the module.
+ *
+ * ```js
+ * import { Pubstack } from '@highfivve/module-sticky-footer-ads';
+ * moli.registerModule(new StickyFooterAds({
+ *   mobileStickyDomId: 'ad-mobile-sticky',
+ *   desktopFloorAdDomId: 'ad-floorad',
+ *   disallowedAdvertiserIds: [ 111111, 222222 ]
+ * }, window));
+ * ```
+ *
+ * Next you need to add the required HTML and CSS on your page. See the [footer ads documentation](https://highfivve.github.io/footer-ads/)
+ *
+ * **Important**
+ * The `data-ref`s are not configurable and are currently hardcoded. Make sure that they are correct.
+ *
+ * ## Resources
+ *
+ * - [Documentation](https://highfivve.github.io/footer-ads/)
+ *
+ * @module
+ */
+import { Moli, IModule, ModuleType, mkInitStep, IAssetLoaderService } from '@highfivve/ad-tag';
+import { setupFooterAdListener } from './desktopFloorAd';
+import { initAdSticky } from './mobileSticky';
+
+export type StickyFooterAdConfig = {
+  /**
+   */
+  readonly mobileStickyDomId?: string;
+
+  readonly desktopFloorAdDomId?: string;
+
+  /**
+   * Disable rendering the footer ad format for certain advertisers by specifying them here.
+   * Most of the time you would use this for partners who ship their own special format or behaviour.
+   *
+   */
+  readonly disallowedAdvertiserIds: number[];
+};
+
+/**
+ * ## Sticky Footer Ads
+ *
+ * Provides the javascript integration for sticky  footer ads, which consist of
+ *
+ * - close button feature
+ * - removing HTML if the advertiser provides the entire ad creative
+ * - removing HTML if ad is empty
+ * - showing HTML if ad is none-empty
+ *
+ * @see https://highfivve.github.io/footer-ads/
+ */
+export class StickyFooterAds implements IModule {
+  public readonly name: string = 'sticky-footer-ads';
+  public readonly description: string = 'sticky footer ad creatives';
+  public readonly moduleType: ModuleType = 'creatives';
+
+  constructor(private readonly stickyFooterAdConfig: StickyFooterAdConfig) {}
+
+  config(): Object | null {
+    return this.stickyFooterAdConfig;
+  }
+
+  init(config: Moli.MoliConfig, assetLoaderService: IAssetLoaderService): void {
+    // direct prebid events
+    // init additional pipeline steps if not already defined
+    config.pipeline = config.pipeline || {
+      initSteps: [],
+      configureSteps: [],
+      prepareRequestAdsSteps: []
+    };
+
+    config.pipeline.initSteps.push(
+      mkInitStep('pubstack', ctx => {
+        if (this.stickyFooterAdConfig.mobileStickyDomId) {
+          initAdSticky(
+            ctx.window,
+            ctx.env,
+            ctx.logger,
+            this.stickyFooterAdConfig.mobileStickyDomId,
+            this.stickyFooterAdConfig.disallowedAdvertiserIds
+          );
+        }
+        if (this.stickyFooterAdConfig.desktopFloorAdDomId) {
+          setupFooterAdListener(
+            ctx.window,
+            ctx.env,
+            ctx.logger,
+            this.stickyFooterAdConfig.desktopFloorAdDomId,
+            this.stickyFooterAdConfig.disallowedAdvertiserIds
+          );
+        }
+        return Promise.resolve();
+      })
+    );
+  }
+}

--- a/modules/sticky-footer-ads/mobileSticky.ts
+++ b/modules/sticky-footer-ads/mobileSticky.ts
@@ -1,0 +1,76 @@
+import { googletag, Moli } from '@highfivve/ad-tag';
+
+const adStickyContainerDataRef = '[data-ref=sticky-ad]';
+const adStickyCloseButtonDataRef = '[data-ref=sticky-ad-close]';
+
+/**
+ * ## Ad Sticky
+ *
+ * Initializes the close button for the sticky ad.
+ */
+export const initAdSticky = (
+  window: Window & googletag.IGoogleTagWindow,
+  env: Moli.Environment,
+  log: Moli.MoliLogger,
+  mobileStickyDomId: string,
+  disallowedAdvertiserIds: number[]
+): void => {
+  const adSticky = window.document.querySelector<HTMLElement>(adStickyContainerDataRef);
+  const closeButton = window.document.querySelector(adStickyCloseButtonDataRef);
+
+  if (adSticky && closeButton) {
+    closeButton.addEventListener(
+      'click',
+      () => {
+        // hide the ad slot
+        adSticky.style.setProperty('display', 'none');
+
+        // destroy the slot so it doesn't get reloaded or refreshed by accident
+        const slot = window.googletag
+          .pubads()
+          .getSlots()
+          .find(slot => slot.getSlotElementId() === mobileStickyDomId);
+
+        // there are cases where the ad slot is not there. This may be the case when
+        // * the ad slot has already been deleted (user clicked two times on the button)
+        // * some weird ad blocker stuff
+        // * ad reload may have already removed the slot
+        if (slot) {
+          window.googletag.destroySlots([slot]);
+        }
+      },
+      // the slot can only be hidden once
+      { once: true, passive: true }
+    );
+
+    // hide mobile sticky for advertiser with custom mobile sticky creative
+    if (env === 'production') {
+      const listener = (event: googletag.events.ISlotRenderEndedEvent): void => {
+        if (event.slot.getSlotElementId() !== mobileStickyDomId) {
+          return;
+        }
+
+        if (
+          event.isEmpty ||
+          // don't render for excluded advertiser ids
+          (!!event.advertiserId && disallowedAdvertiserIds.includes(event.advertiserId))
+        ) {
+          window.googletag.destroySlots([event.slot]);
+          if (adSticky) {
+            adSticky.remove();
+          }
+          window.googletag.pubads().removeEventListener('slotRenderEnded', listener);
+        }
+      };
+
+      window.googletag.pubads().addEventListener('slotRenderEnded', listener);
+    }
+  } else {
+    log.warn(
+      '[mobile-sticky]',
+      `Could not find adSticky container ${adStickyContainerDataRef} or closeButton ${adStickyCloseButtonDataRef}`,
+      adSticky,
+      closeButton
+    );
+  }
+};

--- a/modules/sticky-footer-ads/package.json
+++ b/modules/sticky-footer-ads/package.json
@@ -1,0 +1,53 @@
+{
+  "name": "@highfivve/module-sticky-footer-ads",
+  "version": "3.45.1",
+  "license": "Apache-2.0",
+  "description": "Business logic for sticky footer ads",
+  "main": "./lib/index.js",
+  "typings": "./lib/index.d.ts",
+  "files": [
+    "lib"
+  ],
+  "scripts": {
+    "setup": "yarn",
+    "make:nodemodule": "tsc -p tsconfig.build.json",
+    "compile": "tsc --noEmit",
+    "lint": "yarn lint:ts",
+    "lint:ts": "eslint ./ --ext .ts,.tsx && yarn prettier",
+    "lint:ts:fix": "eslint ./ --ext .ts,.tsx --fix && yarn prettier --write",
+    "prettier": "prettier --config ../../.prettierrc --ignore-path ../../.prettierignore --check \"**/*.ts*\"",
+    "validate": "yarn compile && yarn lint",
+    "validate:github": "yarn validate",
+    "validate:jenkins": "yarn validate"
+  },
+  "repository": {
+    "type": "git",
+    "url": "ssh://git@github.com:highfivve/moli-ad-tag.git",
+    "directory": "modules/pubstack"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/"
+  },
+  "engines": {
+    "node": ">=16.0"
+  },
+  "devDependencies": {
+    "@types/chai": "4.2.18",
+    "@types/jsdom": "16.2.10",
+    "@types/mocha": "8.2.2",
+    "@types/sinon": "10.0.0",
+    "@types/sinon-chai": "3.2.5",
+    "chai": "4.3.4",
+    "mocha": "8.4.0",
+    "mocha-junit-reporter": "2.0.0",
+    "sinon": "10.0.0",
+    "sinon-chai": "3.6.0",
+    "ts-loader": "^9.2.1",
+    "ts-node": "^9.1.1",
+    "typedoc": "^0.20.36",
+    "typescript": "^4.2.4"
+  },
+  "dependencies": {
+    "@highfivve/ad-tag": "^3.45.1"
+  }
+}

--- a/modules/sticky-footer-ads/tsconfig.build.json
+++ b/modules/sticky-footer-ads/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "compilerOptions": {
+    "outDir": "./lib"
+  },
+  "include": ["./*"],
+  "exclude": ["./*.test.ts"]
+}

--- a/modules/sticky-footer-ads/tsconfig.json
+++ b/modules/sticky-footer-ads/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.modules.json",
+}

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -138,6 +138,7 @@ module.exports = {
           '../modules/prebid-first-party-data/index.ts',
           '../modules/pubstack/index.ts',
           '../modules/sovrn-ad-reload/index.ts',
+          '../modules/sticky-footer-ads/index.ts',
           '../modules/yield-optimization/index.ts',
           '../modules/zeotap/zeotap.ts'
         ],


### PR DESCRIPTION
Removes the need for custom javascript on the publisher page.
Publisher only needs to add some additional HTML and CSS.

See: https://highfivve.github.io/footer-ads/