### PR TITLE
GD-2171 Add support to skip schain node appending

### DIFF
--- a/ad-tag/source/ts/ads/prebid.ts
+++ b/ad-tag/source/ts/ads/prebid.ts
@@ -94,7 +94,11 @@ export const prebidConfigure = (
             ...prebidConfig.config,
             ...{ floors: prebidConfig.config.floors || {} } // for module priceFloors
           });
-          prebidConfig.schain.nodes.forEach(({ bidder, node }) => {
+          prebidConfig.schain.nodes.forEach(({ bidder, node, appendNode }) => {
+            const nodes = [schainConfig.supplyChainStartNode];
+            if (appendNode) {
+              nodes.push(node);
+            }
             context.window.pbjs.setBidderConfig({
               bidders: [bidder],
               config: {
@@ -103,7 +107,7 @@ export const prebidConfigure = (
                   config: {
                     ver: '1.0',
                     complete: 1,
-                    nodes: [schainConfig.supplyChainStartNode, node]
+                    nodes
                   }
                 }
               }

--- a/ad-tag/source/ts/types/moli.ts
+++ b/ad-tag/source/ts/types/moli.ts
@@ -1350,7 +1350,16 @@ export namespace Moli {
 
     export type BidderSupplyChainNode = {
       readonly bidder: prebidjs.BidderCode;
+
+      /**
+       * The bidder specific supply chain node
+       */
       readonly node: SupplyChainObject.ISupplyChainNode;
+
+      /**
+       * if true the `node` will be added to the supply chain configuration.
+       */
+      readonly appendNode: boolean;
     };
 
     export interface PrebidConfig {


### PR DESCRIPTION
Nodes in the prebid schain configuration can now be skipped. This covers now all three use cases that there are apperantly:

1. No schain support at all - no entry for the bidder in the `schain.nodes` array
2. Bidder adds itself to the schain object - `appendNode = false`
3. Bidder does not add itself to the schain object - `appendNode = true`

```ts
import { Moli } from '@highfivve/ad-tag';

export const prebidSchainConfig: Moli.headerbidding.BidderSupplyChainNode[] = [
  {
    bidder: 'bidderA',
    appendNode: true,
    node: {
      asi: 'biddera.com',
      sid: '123',
      hp: 1
    }
  },
   {
    bidder: 'bidderA',
    appendNode: false,
    node: {
      asi: 'bidderb.com',
      sid: '123',
      hp: 1
    }
  },
];

```