### PR TITLE
GD-5347: Prebid-First-Party-Data mapping for iab content data segments

### DIFF
--- a/ad-tag/source/ts/types/prebidjs.ts
+++ b/ad-tag/source/ts/types/prebidjs.ts
@@ -1672,10 +1672,62 @@ export namespace prebidjs {
          * Content language using ISO-639-1-alpha-2.
          */
         language?: string;
+
+        /**
+         * Additional content data. Each object represents a different data source.
+         */
+        data?: OpenRtb2Data[];
       };
 
       /**
        * Placeholder for exchange-specific extensions to OpenRTB
+       */
+      ext?: any;
+    }
+
+    /**
+     * Data segment that allos additional data about the related object (e.g. content).
+     */
+    export interface OpenRtb2Data {
+      /**
+       * Exchange-specific ID for the data provider.
+       */
+      id?: string;
+
+      /**
+       * Exchange-specific name for the data provider.
+       */
+      name: string;
+
+      /**
+       * Array of OpenRtb2Segment objects that contain the actual data values.
+       */
+      segment: OpenRtb2Segment[];
+
+      /**
+       * Placeholder for exchange-specific extensions to OpenRTB.
+       */
+      ext?: any;
+    }
+
+    /**
+     * Segment objects are essentially key-value pairs that convey specific units of data.
+     */
+    export interface OpenRtb2Segment {
+      /**
+       * ID of the data segment specific to the data provider.
+       */
+      id?: string;
+      /**
+       * Name of the data segment specific to the data provider.
+       */
+      name?: string;
+      /**
+       * String representation of the data segment value.
+       */
+      value?: string;
+      /**
+       * Placeholder for exchange-specific extensions to OpenRTB.
        */
       ext?: any;
     }
@@ -4682,8 +4734,8 @@ export namespace prebidjs {
     readonly sendStandardTargeting?: boolean;
 
     /**
-     * 	If custom adserverTargeting functions are specified that may generate empty keys, this can be used to suppress them.
-     * 	@default false
+     *  If custom adserverTargeting functions are specified that may generate empty keys, this can be used to suppress them.
+     *  @default false
      */
     readonly suppressEmptyKeys?: boolean;
 
@@ -4747,9 +4799,9 @@ export namespace prebidjs {
       readonly enforcement?: IFloorEnforcementConfig;
 
       /**
-       * 	The mimimum CPM floor used by the Price Floors Module (as of 4.13).
-       * 	The Price Floors Module will take the greater of floorMin and the
-       * 	matched rule CPM when evaluating `getFloor()` and enforcing floors.
+       *  The mimimum CPM floor used by the Price Floors Module (as of 4.13).
+       *  The Price Floors Module will take the greater of floorMin and the
+       *  matched rule CPM when evaluating `getFloor()` and enforcing floors.
        */
       readonly floorMin?: number;
 
@@ -4762,12 +4814,12 @@ export namespace prebidjs {
       readonly floorProvider?: string;
 
       /**
-       * 	`skipRate` is a random function whose input value is any integer 0 through 100 to determine when to skip all
-       * 	floor logic, where 0 is always use floor data and 100 is always skip floor data. The use case is for
-       * 	publishers or floor providers to learn bid behavior when floors are applied or skipped. Analytics adapters
-       * 	will have access to model version (if defined) when skipped is true to signal the Price Floors Module is in
-       * 	floors mode. If skipRate is supplied in both the root level of the floors object and within the data object,
-       * 	the skipRate configuration within the data object shall prevail.
+       *  `skipRate` is a random function whose input value is any integer 0 through 100 to determine when to skip all
+       *  floor logic, where 0 is always use floor data and 100 is always skip floor data. The use case is for
+       *  publishers or floor providers to learn bid behavior when floors are applied or skipped. Analytics adapters
+       *  will have access to model version (if defined) when skipped is true to signal the Price Floors Module is in
+       *  floors mode. If skipRate is supplied in both the root level of the floors object and within the data object,
+       *  the skipRate configuration within the data object shall prevail.
        * @default 0
        */
       readonly skipRate?: number;
@@ -4893,6 +4945,7 @@ export namespace prebidjs {
        */
       [key: string]: number;
     }
+
     /**
      * IFloor module for adUnit.
      * @see https://docs.prebid.org/dev-docs/modules/floors.html
@@ -4936,8 +4989,8 @@ export namespace prebidjs {
       readonly skipRate?: number;
 
       /**
-       * 	Currency of floor data. Floor Module will convert currency where
-       * 	necessary. See Currency section for more details.
+       *  Currency of floor data. Floor Module will convert currency where
+       *  necessary. See Currency section for more details.
        */
       readonly currency?: currency.ICurrency;
 

--- a/modules/prebid-first-party-data/index.test.ts
+++ b/modules/prebid-first-party-data/index.test.ts
@@ -74,12 +74,17 @@ describe('Prebid First Party Data Module', () => {
 
   const createFpdModule = (
     staticPrebidFirstPartyData: prebidjs.firstpartydata.PrebidFirstPartyData,
-    gptTargetingMappings?: GptTargetingMapping
+    gptTargetingMappings?: GptTargetingMapping,
+    iabDataProviderName?: string
   ): PrebidFirstPartyDataModule => {
-    return new PrebidFirstPartyDataModule({
-      staticPrebidFirstPartyData,
-      gptTargetingMappings
-    });
+    return new PrebidFirstPartyDataModule(
+      {
+        staticPrebidFirstPartyData,
+        gptTargetingMappings,
+        iabDataProviderName
+      },
+      jsDomWindow
+    );
   };
 
   const initModule = (module: PrebidFirstPartyDataModule) => {
@@ -144,12 +149,15 @@ describe('Prebid First Party Data Module', () => {
     it('should call pbjs.setConfig() with the configured first party data', async () => {
       const module = createFpdModule(
         { user: { gender: 'O', yob: 1337, keywords: 'some,nice,guy' } },
-        { cat: 'openrtb2_cat', pageCat: 'openrtb2_page_cat' }
+        { cat: 'openrtb2_cat', pageCat: 'openrtb2_page_cat', iabV3: 'iab_v3', iabV2: 'iab_v2' },
+        'test.com'
       );
 
       const { moliConfig, targeting, configureStep } = initModule(module);
       targeting.keyValues.openrtb2_cat = ['IAB-1'];
       targeting.keyValues.openrtb2_page_cat = ['IAB-1', 'IAB-123'];
+      targeting.keyValues.iab_v3 = ['123', '456'];
+      targeting.keyValues.iab_v2 = ['111', '222'];
 
       await configureStep(adPipelineContext(moliConfig), []);
 
@@ -157,7 +165,39 @@ describe('Prebid First Party Data Module', () => {
         site: {
           cat: ['IAB-1'],
           sectioncat: ['IAB-1'],
-          pagecat: ['IAB-1', 'IAB-123']
+          pagecat: ['IAB-1', 'IAB-123'],
+          content: {
+            data: [
+              {
+                name: 'test.com',
+                ext: {
+                  segtax: 6
+                },
+                segment: [
+                  {
+                    id: '111'
+                  },
+                  {
+                    id: '222'
+                  }
+                ]
+              },
+              {
+                name: 'test.com',
+                ext: {
+                  segtax: 7
+                },
+                segment: [
+                  {
+                    id: '123'
+                  },
+                  {
+                    id: '456'
+                  }
+                ]
+              }
+            ]
+          }
         },
         user: {
           gender: 'O',


### PR DESCRIPTION
This allows setting the `site.content.data` object with data from the publisher itself containing iabV2 or iabV3 ids.
Refer to https://docs.prebid.org/features/firstPartyData.html#segments-and-taxonomy for more documentation.