### PR TITLE
Support consent.enabled false

### DIFF
--- a/ad-tag/source/ts/ads/consent.ts
+++ b/ad-tag/source/ts/ads/consent.ts
@@ -53,7 +53,7 @@ export const consentReady = (
   log: Moli.MoliLogger,
   env: Moli.Environment | undefined
 ): Promise<tcfapi.responses.TCData> => {
-  if (env === 'test') {
+  if (env === 'test' || consentConfig.enabled === false) {
     return Promise.resolve({
       gdprApplies: false,
       eventStatus: EventStatus.TC_LOADED,

--- a/ad-tag/source/ts/types/moli.ts
+++ b/ad-tag/source/ts/types/moli.ts
@@ -1110,6 +1110,18 @@ export namespace Moli {
      */
     export interface ConsentConfig {
       /**
+       * Disables consent handling the ad tag. This has a handful of use cases
+       *
+       * 1. Debugging and testing, when the CMP has issues
+       * 2. Disable for regions without data privacy legislation
+       *
+       * When disabled, moli will provide default values for
+       *
+       * * the `tcData` object in the ad request context. `gdprApplies` will be `0`
+       */
+      readonly enabled?: boolean;
+
+      /**
        * If set to `true` ad requests will be aborted when there's only
        * legitimate interest established for at least one purpose.
        */


### PR DESCRIPTION
Provide default `tcData` (`gdprApplies=0`) via configuration flag