### PR TITLE
Add apexDomain to labels

### DIFF
--- a/ad-tag/source/ts/ads/adPipeline.test.ts
+++ b/ad-tag/source/ts/ads/adPipeline.test.ts
@@ -326,6 +326,44 @@ describe('AdPipeline', () => {
 
       expect(supportedLabels).to.contain('purpose-1');
     });
+
+    it('should localhost as domain', async () => {
+      dom.window.__tcfapi = tcfapiFunction(tcDataNoGdpr);
+      let supportedLabels: string[] = [];
+      const configureStep: ConfigureStep[] = [
+        context => {
+          supportedLabels = context.labelConfigService.getSupportedLabels();
+          return Promise.resolve();
+        }
+      ];
+      const pipeline = newAdPipeline({ ...emptyPipelineConfig, configure: configureStep });
+      await pipeline.run([adSlot], emptyConfig, 1);
+
+      expect(supportedLabels).to.contain('localhost');
+    });
+
+    it('should the apex domain from window.location.hostname ', async () => {
+      const domWithLocation = createDom({ url: 'https://www.example.com' });
+      domWithLocation.window.__tcfapi = tcfapiFunction(tcDataNoGdpr);
+      let supportedLabels: string[] = [];
+      const configureStep: ConfigureStep[] = [
+        context => {
+          supportedLabels = context.labelConfigService.getSupportedLabels();
+          return Promise.resolve();
+        }
+      ];
+
+      const pipeline = new AdPipeline(
+        { ...emptyPipelineConfig, configure: configureStep },
+        noopLogger,
+        domWithLocation.window as any,
+        reportingService
+      );
+
+      await pipeline.run([adSlot], emptyConfig, 1);
+
+      expect(supportedLabels).to.contain('example.com');
+    });
   });
 
   describe('mkConfigureStepOnce', () => {

--- a/ad-tag/source/ts/ads/adPipeline.ts
+++ b/ad-tag/source/ts/ads/adPipeline.ts
@@ -8,6 +8,7 @@ import { consentReady } from './consent';
 import { googletag } from '../types/googletag';
 import { prebidjs } from '../types/prebidjs';
 import TCPurpose = tcfapi.responses.TCPurpose;
+import { extractDomainFromHostname } from '../util/extractDomainFromHostname';
 
 /**
  * Context passed to every pipeline step.
@@ -317,6 +318,13 @@ export class AdPipeline {
         extraLabels.push('purpose-1');
       } else if (!consentData.gdprApplies) {
         extraLabels.push('purpose-1');
+      }
+
+      // make the apex domain available for every request. This allows for granular domain level targeting.
+      // note that there's no fallback mechanism now, which leaves "translate" pages or iframe integrations unsupported
+      const domain = extractDomainFromHostname(this.window.location.hostname);
+      if (domain) {
+        extraLabels.push(domain);
       }
 
       const labelConfigService = new LabelConfigService(

--- a/ad-tag/source/ts/stubs/browserEnvSetup.ts
+++ b/ad-tag/source/ts/stubs/browserEnvSetup.ts
@@ -1,8 +1,11 @@
 import jsdom from 'jsdom';
 
-export const createDom = (): jsdom.JSDOM => {
+export type CreateDomOptions = {
+  readonly url?: string;
+};
+export const createDom = (options?: CreateDomOptions): jsdom.JSDOM => {
   const dom = new jsdom.JSDOM('', {
-    url: 'http://localhost',
+    url: options?.url ?? 'http://localhost',
     referrer: 'http://localhost',
     contentType: 'text/html'
   });


### PR DESCRIPTION
Adds the apexDomain to supported labels. This allows for granular targeting of bid objects