### PR TITLE
Always initialize google tag queue

### DIFF
--- a/ad-tag/source/ts/ads/googleAdManager.ts
+++ b/ad-tag/source/ts/ads/googleAdManager.ts
@@ -110,7 +110,7 @@ export const gptInit = (assetLoader: IAssetLoaderService): InitStep => {
         // These are two separate steps to fix race conditions, when window.googletag is set for unknown reasons,
         // but window.googletag.cmd is not. The thesis is that gpt.js is loading before `cmd` is set, but doesn't provide
         // it by itself.
-        context.window.googletag = context.window.googletag || {};
+        context.window.googletag = context.window.googletag || ({} as any);
         context.window.googletag.cmd = context.window.googletag.cmd || [];
         context.window.googletag.cmd.push(resolve);
 


### PR DESCRIPTION
There's a very weird race condition happening in next.js while fastly navigating a page.

![image](https://user-images.githubusercontent.com/647727/234288436-0e000b38-dfb8-4924-ba16-93840ae448a2.png)

This fix contains the solution proposed by google.

![image](https://user-images.githubusercontent.com/647727/234288819-da49dc3f-9821-4970-927e-2040d1a818b1.png)
