### PR TITLE
Read old version from version.json instead of package.json in moli-release

### DIFF
--- a/moli-release/src/types/packageJson.ts
+++ b/moli-release/src/types/packageJson.ts
@@ -4,7 +4,6 @@
 export interface IPackageJson {
   /**
    * The version number in the package.json.
-   * This value is taken as 'current version'. The script will increment the version and set this as default value.
    */
   version: string;
 }

--- a/moli-release/src/types/versionJson.ts
+++ b/moli-release/src/types/versionJson.ts
@@ -1,0 +1,10 @@
+/**
+ * All necessary information we need from the version.json to read and update values.
+ */
+export interface IVersionJson {
+  /**
+   * The current version of the ad-tag release.
+   * This value is taken as 'current version'. The script will increment the version and set this as default value.
+   */
+  currentVersion: string;
+}


### PR DESCRIPTION
This prevents problems when using moli-code-gen with the new `--init` parameter