### PR TITLE
GD-6594 remove margin for prebid only rendered iframes

### DIFF
--- a/ad-tag/source/ts/ads/prebid.ts
+++ b/ad-tag/source/ts/ads/prebid.ts
@@ -532,7 +532,11 @@ export const prebidRenderAds =
                     // internally prebid uses document.write or inserts an element. Either way, this is safe to do here.
                     // document.write is sync.
                     // see https://github.com/prebid/Prebid.js/blob/92daa81f277598cbed486cf8be01ce796aa80c8f/src/prebid.js#L555-L588
-                    iframe.contentDocument?.body.style.setProperty('margin', '0');
+
+                    const normalizeCss = `/*! normalize.css v8.0.1 | MIT License | github.com/necolas/normalize.css */button,hr,input{overflow:visible}progress,sub,sup{vertical-align:baseline}[type=checkbox],[type=radio],legend{box-sizing:border-box;padding:0}html{line-height:1.15;-webkit-text-size-adjust:100%}body{margin:0}details,main{display:block}h1{font-size:2em;margin:.67em 0}hr{box-sizing:content-box;height:0}code,kbd,pre,samp{font-family:monospace,monospace;font-size:1em}a{background-color:transparent}abbr[title]{border-bottom:none;text-decoration:underline;text-decoration:underline dotted}b,strong{font-weight:bolder}small{font-size:80%}sub,sup{font-size:75%;line-height:0;position:relative}sub{bottom:-.25em}sup{top:-.5em}img{border-style:none}button,input,optgroup,select,textarea{font-family:inherit;font-size:100%;line-height:1.15;margin:0}button,select{text-transform:none}[type=button],[type=reset],[type=submit],button{-webkit-appearance:button}[type=button]::-moz-focus-inner,[type=reset]::-moz-focus-inner,[type=submit]::-moz-focus-inner,button::-moz-focus-inner{border-style:none;padding:0}[type=button]:-moz-focusring,[type=reset]:-moz-focusring,[type=submit]:-moz-focusring,button:-moz-focusring{outline:ButtonText dotted 1px}fieldset{padding:.35em .75em .625em}legend{color:inherit;display:table;max-width:100%;white-space:normal}textarea{overflow:auto}[type=number]::-webkit-inner-spin-button,[type=number]::-webkit-outer-spin-button{height:auto}[type=search]{-webkit-appearance:textfield;outline-offset:-2px}[type=search]::-webkit-search-decoration{-webkit-appearance:none}::-webkit-file-upload-button{-webkit-appearance:button;font:inherit}summary{display:list-item}[hidden],template{display:none}`;
+                    const iframeStyle = iframeDoc.createElement('style');
+                    iframeStyle.appendChild(iframeDoc.createTextNode(normalizeCss));
+                    iframeDoc.head.appendChild(iframeStyle);
                   } else {
                     context.logger.error(
                       'Prebid',


### PR DESCRIPTION
most browsers have a default margin of 8px . We add those after prebid has written to the iframe.
internally prebid uses document.write or inserts an element. Either way, this is safe to do here.
document.write is sync.
see https://github.com/prebid/Prebid.js/blob/92daa81f277598cbed486cf8be01ce796aa80c8f/src/prebid.js#L555-L588