### PR TITLE
Emetriq login event

### DIFF
--- a/modules/emetriq/index.test.ts
+++ b/modules/emetriq/index.test.ts
@@ -7,13 +7,20 @@ import {
   createAssetLoaderService
 } from '@highfivve/ad-tag/source/ts/util/assetLoaderService';
 
-import { Emetriq, EmetriqAppConfig, EmetriqWebConfig } from './index';
+import {
+  Emetriq,
+  EmetriqAppConfig,
+  EmetriqLoginEventConfig,
+  EmetriqModuleConfig,
+  EmetriqWebConfig
+} from './index';
 import { emptyConfig, newEmptyConfig, noopLogger } from '@highfivve/ad-tag/lib/stubs/moliStubs';
 import { AdPipelineContext, prebidjs } from '@highfivve/ad-tag';
 import { fullConsent, tcDataNoGdpr } from '@highfivve/ad-tag/lib/stubs/consentStubs';
 import { EmetriqWindow } from './types/emetriq';
 import { trackInApp } from './trackInApp';
 import { createPbjsStub } from '@highfivve/ad-tag/lib/stubs/prebidjsStubs';
+import { trackLoginEvent } from './trackLoginEvent';
 
 // setup sinon-chai
 use(sinonChai);
@@ -193,16 +200,7 @@ describe('Emetriq Module', () => {
     });
   });
 
-  describe('trackInApp', () => {
-    const appConfig: EmetriqAppConfig = {
-      sid: 123,
-      os: 'android',
-      appId: 'com.highfivve.app',
-      advertiserIdKey: 'advertiserId',
-      linkOrKeyword: {
-        keywords: 'pokemon'
-      }
-    };
+  describe('tracking APIs', () => {
     jsDomWindow.fetch = (input: RequestInfo | URL, init?: RequestInit): Promise<Response> =>
       Promise.resolve({} as any);
     let fetchSpy = sandbox.spy(jsDomWindow, 'fetch');
@@ -214,20 +212,67 @@ describe('Emetriq Module', () => {
       fetchSpy = sandbox.spy(jsDomWindow, 'fetch');
     });
 
-    it('should call the endpoint with keywords ', async () => {
-      await trackInApp(adPipelineContext(), appConfig, {}, {}, fetchSpy, noopLogger);
-      expect(fetchSpy).to.have.been.calledOnce;
-      const [urlCalled] = fetchSpy.firstCall.args;
-      expect(urlCalled).to.be.eq(
-        `https://aps.xplosion.de/data?sid=123&os=android&app_id=com.highfivve.app&keywords=pokemon&gdpr=1&gdpr_consent=${tcDataWithConsent.tcString}`
-      );
-    });
+    describe('trackInApp', () => {
+      const appConfig: EmetriqAppConfig = {
+        sid: 123,
+        os: 'android',
+        appId: 'com.highfivve.app',
+        advertiserIdKey: 'advertiserId',
+        linkOrKeyword: {
+          keywords: 'pokemon'
+        }
+      };
 
-    ['ios' as const, 'android' as const].forEach(os =>
-      it(`should call the endpoint with the os parameter ${os}`, async () => {
+      it('should call the endpoint with keywords ', async () => {
+        await trackInApp(adPipelineContext(), appConfig, {}, {}, fetchSpy, noopLogger);
+        expect(fetchSpy).to.have.been.calledOnce;
+        const [urlCalled] = fetchSpy.firstCall.args;
+        expect(urlCalled).to.be.eq(
+          `https://aps.xplosion.de/data?sid=123&os=android&app_id=com.highfivve.app&keywords=pokemon&gdpr=1&gdpr_consent=${tcDataWithConsent.tcString}`
+        );
+      });
+
+      ['ios' as const, 'android' as const].forEach(os =>
+        it(`should call the endpoint with the os parameter ${os}`, async () => {
+          await trackInApp(
+            adPipelineContext(),
+            { ...appConfig, os: os },
+            {},
+            {},
+            fetchSpy,
+            noopLogger
+          );
+          expect(fetchSpy).to.have.been.calledOnce;
+          const [urlCalled] = fetchSpy.firstCall.args;
+          expect(urlCalled).to.be.eq(
+            `https://aps.xplosion.de/data?sid=123&os=${os}&app_id=com.highfivve.app&keywords=pokemon&gdpr=1&gdpr_consent=${tcDataWithConsent.tcString}`
+          );
+        })
+      );
+
+      it('should call the endpoint with link set ', async () => {
+        const appConfigWithLink = {
+          ...appConfig,
+          linkOrKeyword: {
+            link: 'https://www.example.com?param=foo'
+          }
+        };
+        await trackInApp(adPipelineContext(), appConfigWithLink, {}, {}, fetchSpy, noopLogger);
+        expect(fetchSpy).to.have.been.calledOnce;
+        const [urlCalled] = fetchSpy.firstCall.args;
+        expect(urlCalled).to.be.eq(
+          `https://aps.xplosion.de/data?sid=123&os=android&app_id=com.highfivve.app&link=https%3A%2F%2Fwww.example.com%3Fparam%3Dfoo&gdpr=1&gdpr_consent=${tcDataWithConsent.tcString}`
+        );
+      });
+
+      it('should call the endpoint with advertiserIdKey as device_id if provided ', async () => {
+        const advertiserId = '8744bceb-91e5-4c20-8fe9-3fdddb13107f';
         await trackInApp(
-          adPipelineContext(),
-          { ...appConfig, os: os },
+          {
+            ...adPipelineContext(),
+            config: { ...emptyConfig, targeting: { keyValues: { advertiserId } } }
+          },
+          appConfig,
           {},
           {},
           fetchSpy,
@@ -236,132 +281,196 @@ describe('Emetriq Module', () => {
         expect(fetchSpy).to.have.been.calledOnce;
         const [urlCalled] = fetchSpy.firstCall.args;
         expect(urlCalled).to.be.eq(
-          `https://aps.xplosion.de/data?sid=123&os=${os}&app_id=com.highfivve.app&keywords=pokemon&gdpr=1&gdpr_consent=${tcDataWithConsent.tcString}`
+          `https://aps.xplosion.de/data?sid=123&device_id=${advertiserId}&os=android&app_id=com.highfivve.app&keywords=pokemon&gdpr=1&gdpr_consent=${tcDataWithConsent.tcString}`
         );
-      })
-    );
+      });
 
-    it('should call the endpoint with link set ', async () => {
-      const appConfigWithLink = {
-        ...appConfig,
-        linkOrKeyword: {
-          link: 'https://www.example.com?param=foo'
-        }
+      it('should call the endpoint with additional identifier params ', async () => {
+        await trackInApp(
+          adPipelineContext(),
+          {
+            ...appConfig,
+            additionalIdentifier: {
+              id_id5: '20c0c6f5-b89a-42ff-ab34-24da7cccf9ff',
+              id_sharedid: '1c6e063f-feaa-40a0-8a86-b9be3c655c39'
+            }
+          },
+          {},
+          {},
+          fetchSpy,
+          noopLogger
+        );
+        expect(fetchSpy).to.have.been.calledOnce;
+        const [urlCalled] = fetchSpy.firstCall.args;
+        expect(urlCalled).to.be.eq(
+          `https://aps.xplosion.de/data?sid=123&os=android&app_id=com.highfivve.app&keywords=pokemon&id_id5=20c0c6f5-b89a-42ff-ab34-24da7cccf9ff&id_sharedid=1c6e063f-feaa-40a0-8a86-b9be3c655c39&gdpr=1&gdpr_consent=${tcDataWithConsent.tcString}`
+        );
+      });
+
+      it('should call the endpoint with additional custom params ', async () => {
+        await trackInApp(
+          adPipelineContext(),
+          {
+            ...appConfig,
+            additionalIdentifier: {}
+          },
+          {},
+          {
+            c_iabV3Ids: '12,34',
+            c_awesome: 'yes'
+          },
+          fetchSpy,
+          noopLogger
+        );
+        expect(fetchSpy).to.have.been.calledOnce;
+        const [urlCalled] = fetchSpy.firstCall.args;
+        expect(urlCalled).to.be.eq(
+          `https://aps.xplosion.de/data?sid=123&os=android&app_id=com.highfivve.app&keywords=pokemon&c_iabV3Ids=12%2C34&c_awesome=yes&gdpr=1&gdpr_consent=${tcDataWithConsent.tcString}`
+        );
+      });
+
+      it('should call the endpoint with external additional identifier params ', async () => {
+        const id5Id = '20c0c6f5-b89a-42ff-ab34-24da7cccf9ff';
+        const sharedId = '1c6e063f-feaa-40a0-8a86-b9be3c655c39';
+        const liverampId = '303e3571-9f2a-47ec-b62d-457ebfb5f068';
+        await trackInApp(
+          adPipelineContext(),
+          {
+            ...appConfig,
+            additionalIdentifier: {
+              id_id5: id5Id,
+              id_sharedid: '0df51310-5b4d-49eb-989f-0dfb5323170e'
+            }
+          },
+          {
+            id_sharedid: sharedId,
+            id_liveramp: liverampId
+          },
+          {},
+          fetchSpy,
+          noopLogger
+        );
+        expect(fetchSpy).to.have.been.calledOnce;
+        const [urlCalled] = fetchSpy.firstCall.args;
+        expect(urlCalled).to.be.eq(
+          `https://aps.xplosion.de/data?sid=123&os=android&app_id=com.highfivve.app&keywords=pokemon&id_id5=${id5Id}&id_sharedid=${sharedId}&id_liveramp=${liverampId}&gdpr=1&gdpr_consent=${tcDataWithConsent.tcString}`
+        );
+      });
+
+      it('should call endpoint when gdpr does not apply', async () => {
+        await trackInApp(
+          { ...adPipelineContext(), tcData: tcDataNoGdpr },
+          appConfig,
+          {},
+          {},
+          fetchSpy,
+          noopLogger
+        );
+        expect(fetchSpy).to.have.been.calledOnce;
+        const [urlCalled] = fetchSpy.firstCall.args;
+        expect(urlCalled).to.be.eq(
+          `https://aps.xplosion.de/data?sid=123&os=android&app_id=com.highfivve.app&keywords=pokemon&gdpr=0`
+        );
+      });
+    });
+
+    describe('trackLoginEvent', () => {
+      const loginConfig: EmetriqLoginEventConfig = {
+        partner: 'partner-123',
+        guid: 'abc123efg456'
       };
-      await trackInApp(adPipelineContext(), appConfigWithLink, {}, {}, fetchSpy, noopLogger);
-      expect(fetchSpy).to.have.been.calledOnce;
-      const [urlCalled] = fetchSpy.firstCall.args;
-      expect(urlCalled).to.be.eq(
-        `https://aps.xplosion.de/data?sid=123&os=android&app_id=com.highfivve.app&link=https%3A%2F%2Fwww.example.com%3Fparam%3Dfoo&gdpr=1&gdpr_consent=${tcDataWithConsent.tcString}`
-      );
-    });
+      const loginWebConfig: EmetriqWebConfig = {
+        ...webConfig,
+        login: loginConfig
+      };
 
-    it('should call the endpoint with advertiserIdKey as device_id if provided ', async () => {
-      const advertiserId = '8744bceb-91e5-4c20-8fe9-3fdddb13107f';
-      await trackInApp(
-        {
-          ...adPipelineContext(),
-          config: { ...emptyConfig, targeting: { keyValues: { advertiserId } } }
-        },
-        appConfig,
-        {},
-        {},
-        fetchSpy,
-        noopLogger
-      );
-      expect(fetchSpy).to.have.been.calledOnce;
-      const [urlCalled] = fetchSpy.firstCall.args;
-      expect(urlCalled).to.be.eq(
-        `https://aps.xplosion.de/data?sid=123&device_id=${advertiserId}&os=android&app_id=com.highfivve.app&keywords=pokemon&gdpr=1&gdpr_consent=${tcDataWithConsent.tcString}`
-      );
-    });
+      it('should not fetch if login configuration is missing', async () => {
+        await trackLoginEvent(adPipelineContext(), webConfig, fetchSpy, noopLogger);
+        expect(fetchSpy).to.have.not.been.called;
+      });
 
-    it('should call the endpoint with additional identifier params ', async () => {
-      await trackInApp(
-        adPipelineContext(),
-        {
-          ...appConfig,
-          additionalIdentifier: {
-            id_id5: '20c0c6f5-b89a-42ff-ab34-24da7cccf9ff',
-            id_sharedid: '1c6e063f-feaa-40a0-8a86-b9be3c655c39'
-          }
-        },
-        {},
-        {},
-        fetchSpy,
-        noopLogger
-      );
-      expect(fetchSpy).to.have.been.calledOnce;
-      const [urlCalled] = fetchSpy.firstCall.args;
-      expect(urlCalled).to.be.eq(
-        `https://aps.xplosion.de/data?sid=123&os=android&app_id=com.highfivve.app&keywords=pokemon&id_id5=20c0c6f5-b89a-42ff-ab34-24da7cccf9ff&id_sharedid=1c6e063f-feaa-40a0-8a86-b9be3c655c39&gdpr=1&gdpr_consent=${tcDataWithConsent.tcString}`
-      );
-    });
+      it('should call endpoint with idfa for iOS config', async () => {
+        const advertiserId = 'xxxx-yyyy-zzzz';
+        const iosConfig: EmetriqAppConfig = {
+          os: 'ios',
+          sid: sid,
+          appId: 'com.example.app',
+          advertiserIdKey: 'advertiserId',
+          linkOrKeyword: { link: 'http://localhost' },
+          login: loginConfig
+        };
+        await trackLoginEvent(
+          {
+            ...adPipelineContext(),
+            config: { ...emptyConfig, targeting: { keyValues: { advertiserId } } },
+            tcData: tcDataNoGdpr
+          },
+          iosConfig,
+          fetchSpy,
+          noopLogger
+        );
+        expect(fetchSpy).to.have.been.calledOnce;
+        const [urlCalled] = fetchSpy.firstCall.args;
+        expect(urlCalled).to.be.eq(
+          `https://xdn-ttp.de/lns/import-event-partner-123?guid=abc123efg456&gdpr=0&idfa=${advertiserId}`
+        );
+      });
 
-    it('should call the endpoint with additional custom params ', async () => {
-      await trackInApp(
-        adPipelineContext(),
-        {
-          ...appConfig,
-          additionalIdentifier: {}
-        },
-        {},
-        {
-          c_iabV3Ids: '12,34',
-          c_awesome: 'yes'
-        },
-        fetchSpy,
-        noopLogger
-      );
-      expect(fetchSpy).to.have.been.calledOnce;
-      const [urlCalled] = fetchSpy.firstCall.args;
-      expect(urlCalled).to.be.eq(
-        `https://aps.xplosion.de/data?sid=123&os=android&app_id=com.highfivve.app&keywords=pokemon&c_iabV3Ids=12%2C34&c_awesome=yes&gdpr=1&gdpr_consent=${tcDataWithConsent.tcString}`
-      );
-    });
+      it('should call endpoint with adid for android config', async () => {
+        const advertiserId = 'xxxx-yyyy-zzzz';
+        const iosConfig: EmetriqAppConfig = {
+          os: 'android',
+          sid: sid,
+          appId: 'com.example.app',
+          advertiserIdKey: 'advertiserId',
+          linkOrKeyword: { link: 'http://localhost' },
+          login: loginConfig
+        };
+        await trackLoginEvent(
+          {
+            ...adPipelineContext(),
+            config: { ...emptyConfig, targeting: { keyValues: { advertiserId } } },
+            tcData: tcDataNoGdpr
+          },
+          iosConfig,
+          fetchSpy,
+          noopLogger
+        );
+        expect(fetchSpy).to.have.been.calledOnce;
+        const [urlCalled] = fetchSpy.firstCall.args;
+        expect(urlCalled).to.be.eq(
+          `https://xdn-ttp.de/lns/import-event-partner-123?guid=abc123efg456&gdpr=0&adid=${advertiserId}`
+        );
+      });
 
-    it('should call the endpoint with external additional identifier params ', async () => {
-      const id5Id = '20c0c6f5-b89a-42ff-ab34-24da7cccf9ff';
-      const sharedId = '1c6e063f-feaa-40a0-8a86-b9be3c655c39';
-      const liverampId = '303e3571-9f2a-47ec-b62d-457ebfb5f068';
-      await trackInApp(
-        adPipelineContext(),
-        {
-          ...appConfig,
-          additionalIdentifier: {
-            id_id5: id5Id,
-            id_sharedid: '0df51310-5b4d-49eb-989f-0dfb5323170e'
-          }
-        },
-        {
-          id_sharedid: sharedId,
-          id_liveramp: liverampId
-        },
-        {},
-        fetchSpy,
-        noopLogger
-      );
-      expect(fetchSpy).to.have.been.calledOnce;
-      const [urlCalled] = fetchSpy.firstCall.args;
-      expect(urlCalled).to.be.eq(
-        `https://aps.xplosion.de/data?sid=123&os=android&app_id=com.highfivve.app&keywords=pokemon&id_id5=${id5Id}&id_sharedid=${sharedId}&id_liveramp=${liverampId}&gdpr=1&gdpr_consent=${tcDataWithConsent.tcString}`
-      );
-    });
+      it('should call endpoint when gdpr does apply', async () => {
+        const tcData = fullConsent();
+        await trackLoginEvent(
+          { ...adPipelineContext(), tcData },
+          loginWebConfig,
+          fetchSpy,
+          noopLogger
+        );
+        expect(fetchSpy).to.have.been.calledOnce;
+        const [urlCalled] = fetchSpy.firstCall.args;
+        expect(urlCalled).to.be.eq(
+          `https://xdn-ttp.de/lns/import-event-partner-123?guid=abc123efg456&gdpr=1&gdpr_consent=${tcData.tcString}`
+        );
+      });
 
-    it('should call endpoint when gdpr does not apply', async () => {
-      await trackInApp(
-        { ...adPipelineContext(), tcData: tcDataNoGdpr },
-        appConfig,
-        {},
-        {},
-        fetchSpy,
-        noopLogger
-      );
-      expect(fetchSpy).to.have.been.calledOnce;
-      const [urlCalled] = fetchSpy.firstCall.args;
-      expect(urlCalled).to.be.eq(
-        `https://aps.xplosion.de/data?sid=123&os=android&app_id=com.highfivve.app&keywords=pokemon&gdpr=0`
-      );
+      it('should call endpoint when gdpr does not apply', async () => {
+        await trackLoginEvent(
+          { ...adPipelineContext(), tcData: tcDataNoGdpr },
+          loginWebConfig,
+          fetchSpy,
+          noopLogger
+        );
+        expect(fetchSpy).to.have.been.calledOnce;
+        const [urlCalled] = fetchSpy.firstCall.args;
+        expect(urlCalled).to.be.eq(
+          'https://xdn-ttp.de/lns/import-event-partner-123?guid=abc123efg456&gdpr=0'
+        );
+      });
     });
   });
 

--- a/modules/emetriq/index.ts
+++ b/modules/emetriq/index.ts
@@ -85,6 +85,7 @@ import {
 } from './types/emetriq';
 import { trackInApp } from './trackInApp';
 import DfpKeyValueMap = Moli.DfpKeyValueMap;
+import { trackLoginEvent } from './trackLoginEvent';
 
 /**
  * ## Link
@@ -133,6 +134,24 @@ type Mutable<T> = {
   -readonly [P in keyof T]: T[P];
 };
 
+/**
+ * @see https://docs.xdn.emetriq.de/#event-import
+ */
+export interface EmetriqLoginEventConfig {
+  /**
+   * This is a special ID assigned to the partner by emetriq.
+   */
+  readonly partner: string;
+
+  /**
+   * a `Base64` encoded `SHA-256` of user’s email address (in lower case and UTF-8 encoded). For event imports it is
+   * necessary to URL encode it. See [Example GUID hashing](https://docs.xdn.emetriq.de/#hashing) for comparing your implementation with expected results.
+   *
+   * @see https://docs.xdn.emetriq.de/#hashing
+   */
+  readonly guid: string;
+}
+
 export type EmetriqMappingDefinition = {
   /**
    * custom parameter provided to emetriq
@@ -172,6 +191,12 @@ export interface IEmetriqModuleConfig {
    * to a custom parameter that is sent to emetriq.
    */
   readonly customMappingDefinition?: EmetriqMappingDefinition[];
+
+  /**
+   * Optional configuration for login events
+   * @see https://docs.xdn.emetriq.de/#event-import
+   */
+  readonly login?: EmetriqLoginEventConfig;
 }
 
 /**
@@ -282,6 +307,10 @@ export class Emetriq implements IModule {
         // no consent
         if (ctx.tcData.gdprApplies && !ctx.tcData.vendor.consents[this.gvlid]) {
           return Promise.resolve();
+        }
+
+        if (this.moduleConfig.login) {
+          trackLoginEvent(ctx, this.moduleConfig, ctx.window.fetch, ctx.logger);
         }
 
         Emetriq.syncDelay(ctx, this.moduleConfig.syncDelay).then(additionalIdentifier => {

--- a/modules/emetriq/trackInApp.ts
+++ b/modules/emetriq/trackInApp.ts
@@ -20,7 +20,7 @@ const extractDeviceIdParam = (
  * @param additionalIdentifier identifiers derived from an external source such as prebid.js
  * @param additionalCustomParams
  * @param fetch used to call the data endpoint
- * @param logger required for error logging
+ * @param logger proper logging support
  *
  * @see https://doc.emetriq.de/#/inapp/integration
  * @see https://doc.emetriq.de/inapp/api.html#overview

--- a/modules/emetriq/trackLoginEvent.ts
+++ b/modules/emetriq/trackLoginEvent.ts
@@ -1,0 +1,62 @@
+import { AdPipelineContext, Moli } from '@highfivve/ad-tag';
+import { EmetriqModuleConfig } from './index';
+
+const extractAdIdOrIdfa = (
+  context: AdPipelineContext,
+  moduleConfig: EmetriqModuleConfig
+): string | undefined => {
+  if (moduleConfig.os === 'web') {
+    return;
+  }
+  const deviceId = context.config.targeting?.keyValues[moduleConfig.advertiserIdKey];
+  if (deviceId) {
+    return typeof deviceId === 'string' ? deviceId : deviceId[0];
+  }
+  return;
+};
+/**
+ * Sends a tracking request directly to the emetriq data API.
+ * @param context ad pipeline context to retrieve necessary metadata and consent
+ * @param moduleConfig provides details for the data call
+ * @param fetch used to call the login event endpoint
+ * @param logger proper logging support
+ *
+ * @see https://docs.xdn.emetriq.de/#event-import
+ */
+export const trackLoginEvent = (
+  context: AdPipelineContext,
+  moduleConfig: EmetriqModuleConfig,
+  fetch: (input: RequestInfo, init?: RequestInit) => Promise<Response>,
+  logger: Moli.MoliLogger
+): Promise<any> => {
+  if (!moduleConfig.login) {
+    logger.warn('emetriq', 'login configuration missing!');
+    return Promise.resolve();
+  }
+
+  // use modern URL type
+  const url = new URL(`https://xdn-ttp.de/lns/import-event-${moduleConfig.login.partner}`);
+  url.searchParams.append('guid', moduleConfig.login.guid);
+
+  // consent parameter
+  if (context.tcData.gdprApplies) {
+    url.searchParams.append('gdpr', '1');
+    url.searchParams.append('gdpr_consent', context.tcData.tcString);
+  } else {
+    url.searchParams.append('gdpr', '0');
+  }
+
+  const adIdOrIdfa = extractAdIdOrIdfa(context, moduleConfig);
+  if (adIdOrIdfa) {
+    switch (moduleConfig.os) {
+      case 'android':
+        url.searchParams.append('adid', adIdOrIdfa);
+        break;
+      case 'ios':
+        url.searchParams.append('idfa', adIdOrIdfa);
+        break;
+    }
+  }
+
+  return fetch(url.href).catch(error => logger.error(error));
+};


### PR DESCRIPTION
This adds direct support for emetriq login event import: https://docs.xdn.emetriq.de/#event-import

Note that there's currently no way of restricting the login events sent. They are part of an init step, so they are triggered only once.