### PR TITLE
Implement skin detection for GumGum

### DIFF
--- a/ad-tag/source/ts/types/prebidjs.ts
+++ b/ad-tag/source/ts/types/prebidjs.ts
@@ -5102,7 +5102,7 @@ export namespace prebidjs {
      * Exclude<BidderCode, typeof JustPremium | typeof AppNexusAst>;
      * ```
      */
-    readonly bidder: Exclude<BidderCode, typeof JustPremium>;
+    readonly bidder: Exclude<BidderCode, typeof JustPremium | typeof GumGum>;
   }
 
   export interface IJustPremiumBidResponse extends IBidResponse {
@@ -5117,7 +5117,36 @@ export namespace prebidjs {
     readonly format: JustPremiumFormat;
   }
 
-  export type BidResponse = IGenericBidResponse | IJustPremiumBidResponse;
+  /**
+   * The `bidResponse.ad` property contains this value if it's considered a
+   * "wrapper" creative.
+   */
+  export interface IGumGumBidResponseWrapper {
+    /**
+     * Stands for _ad id_ and contains the format delivered.
+     *
+     * - `59` = in-screen cascade (former mobile skin)
+     * - `39` = in-screen expandable (mobile expandable)
+     */
+    readonly auid: number;
+  }
+
+  export interface IGumGumBidResponse extends IBidResponse {
+    /**
+     * narrow this bid response type to justpremium
+     */
+    readonly bidder: typeof GumGum;
+
+    /**
+     * Contains the GumGum ad creative.
+     *
+     * If the `cw` field is set, then it's a "wrapper". Otherwise, it's considered
+     * `markup` and is only a string.
+     */
+    readonly ad: IGumGumBidResponseWrapper | string;
+  }
+
+  export type BidResponse = IGenericBidResponse | IJustPremiumBidResponse | IGumGumBidResponse;
 
   /**
    * The bidderSettings object provides a way to define some behaviors for the platform

--- a/modules/generic-skin/index.test.ts
+++ b/modules/generic-skin/index.test.ts
@@ -332,6 +332,93 @@ describe('Skin Module', () => {
       });
     });
 
+    // ----  GumGum -----
+    const gumgumBidResponse = (
+      ad: prebidjs.IGumGumBidResponseWrapper | string
+    ): prebidjs.IGumGumBidResponse => {
+      return {
+        bidder: prebidjs.GumGum,
+        adId: '',
+        cpm: 10.0,
+        height: 1,
+        width: 1,
+        mediaType: 'banner',
+        source: 'client',
+        ad: ad
+      };
+    };
+    describe('gumgum mobile skin', () => {
+      const config: SkinConfig = {
+        formatFilter: [{ bidder: 'gumgum', auid: 59 }],
+        skinAdSlotDomId: 'mobile-skin-slot',
+        blockedAdSlotDomIds: ['sky-slot'],
+        hideSkinAdSlot: false,
+        hideBlockedSlots: false,
+        enableCpmComparison: false
+      };
+
+      it('should return `BlockOtherSlots` if a gumgum mobile skin was found', () => {
+        const skinConfigEffect = module.getConfigEffect(config, {
+          'mobile-skin-slot': {
+            bids: [gumgumBidResponse({ auid: 59 })]
+          }
+        });
+
+        expect(skinConfigEffect).to.equal(SkinConfigEffect.BlockOtherSlots);
+      });
+
+      it('should return `NoBlocking` if a gumgum mobile skin was found but cpm 0', () => {
+        const skinConfigEffect = module.getConfigEffect(config, {
+          'mobile-skin-slot': {
+            bids: [{ ...gumgumBidResponse({ auid: 59 }), cpm: 0 }]
+          }
+        });
+
+        expect(skinConfigEffect).to.equal(SkinConfigEffect.NoBlocking);
+      });
+
+      it('should return `NoBlocking` if the gumgum format does not match was found', () => {
+        const skinConfigEffect = module.getConfigEffect(config, {
+          'mobile-skin-slot': {
+            bids: [gumgumBidResponse('some markup'), gumgumBidResponse({ auid: 39 })]
+          }
+        });
+
+        expect(skinConfigEffect).to.equal(SkinConfigEffect.NoBlocking);
+      });
+    });
+
+    describe('gumgum no auid', () => {
+      const config: SkinConfig = {
+        formatFilter: [{ bidder: 'gumgum' }],
+        skinAdSlotDomId: 'mobile-skin-slot',
+        blockedAdSlotDomIds: ['sky-slot'],
+        hideSkinAdSlot: false,
+        hideBlockedSlots: false,
+        enableCpmComparison: false
+      };
+
+      it('should return `BlockOtherSlots` if a gumgum mobile skin was found', () => {
+        const skinConfigEffect = module.getConfigEffect(config, {
+          'mobile-skin-slot': {
+            bids: [gumgumBidResponse({ auid: 59 })]
+          }
+        });
+
+        expect(skinConfigEffect).to.equal(SkinConfigEffect.BlockOtherSlots);
+      });
+
+      it('should return `BlockOtherSlots` if a gumgum mobile skin was found with markup', () => {
+        const skinConfigEffect = module.getConfigEffect(config, {
+          'mobile-skin-slot': {
+            bids: [gumgumBidResponse('markup')]
+          }
+        });
+
+        expect(skinConfigEffect).to.equal(SkinConfigEffect.BlockOtherSlots);
+      });
+    });
+
     describe('dspx', () => {
       const config: SkinConfig = {
         formatFilter: [{ bidder: 'dspx' }],

--- a/modules/generic-skin/index.ts
+++ b/modules/generic-skin/index.ts
@@ -100,7 +100,7 @@ export type SkinModuleConfig = {
   readonly trackSkinCpmLow?: (
     cpms: { skin: number; combinedNonSkinSlots: number },
     skinConfig: SkinConfig,
-    skinBid: prebidjs.IJustPremiumBidResponse | prebidjs.IGenericBidResponse
+    skinBid: prebidjs.IBidResponse
   ) => void;
 };
 
@@ -112,6 +112,16 @@ export type JustPremiumFormatFilter = {
 
 export type GumGumFormatFilter = {
   readonly bidder: typeof prebidjs.GumGum;
+
+  /**
+   * Stands for _ad id_ and contains the format delivered.
+   *
+   * - `59` = in-screen cascade (former mobile skin)
+   * - `39` = in-screen expandable (mobile expandable)
+   *
+   * If not set, then the `auid` will not be considered for filtering.
+   */
+  readonly auid?: number;
 };
 
 export type DSPXFormatFilter = {
@@ -239,7 +249,12 @@ export class Skin implements IModule {
           case 'justpremium':
             return bid.bidder === prebidjs.JustPremium && bid.format === filter.format;
           case 'gumgum':
-            return bid.bidder === prebidjs.GumGum;
+            return (
+              bid.bidder === prebidjs.GumGum &&
+              // if auid is set, it must match the bid.ad.auid
+              (filter.auid === undefined ||
+                (typeof bid.ad !== 'string' && bid.ad.auid === filter.auid))
+            );
           case 'dspx':
             return bid.bidder === prebidjs.DSPX;
           case 'visx':


### PR DESCRIPTION
GumGum provides more information about the actualy creative in the `auid` (ad unit id). This can be used in the skin module to block other ad slots for certain ad unit ids (formats)