### PR TITLE
Remove getTCData

### DIFF
--- a/ad-tag/source/ts/types/tcfapi.ts
+++ b/ad-tag/source/ts/types/tcfapi.ts
@@ -36,13 +36,6 @@ export namespace tcfapi {
       callback: (success: boolean) => void,
       listenerId: number
     ): void;
-
-    (
-      command: 'getTCData',
-      version: TCFApiVersion,
-      callback: (tcData: responses.TCData, success: boolean) => void,
-      vendorIds?: number[]
-    ): void;
   }
 
   export namespace responses {

--- a/moli-debugger/components/consentConfig.tsx
+++ b/moli-debugger/components/consentConfig.tsx
@@ -130,17 +130,6 @@ export class ConsentConfig extends Component<{}, IConsentConfigState> {
 
   private initConsentData = (): void => {
     if (window.__tcfapi) {
-      // fetch initial TCData
-      window.__tcfapi('getTCData', 2, (data: tcfapi.responses.TCData) => {
-        const tcModel = data.gdprApplies ? TCString.decode(data.tcString) : undefined;
-        this.setState({
-          gdprApplies: data.gdprApplies,
-          cmpStatus: data.cmpStatus,
-          tcModel: tcModel,
-          tcString: data.gdprApplies ? data.tcString : 'none'
-        });
-      });
-
       // Update on changes
       window.__tcfapi('addEventListener', 2, event => {
         const tcModel = event.gdprApplies ? TCString.decode(event.tcString) : undefined;


### PR DESCRIPTION
TCF 2.2 removes the `getTCData` method.

## resources

- [Technical summary](https://iabtechlab.com/blog/summary-of-technical-changes-tcf-v2-2/)
- https://iabeurope.eu/all-news/tcf-2-2-launches-all-you-need-to-know/
- [TCF 2.2 API Spec](https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/tree/master/TCFv2)