### PR TITLE
Support debug flag via local and session storage

### DIFF
--- a/ad-tag/source/ts/util/logging.test.ts
+++ b/ad-tag/source/ts/util/logging.test.ts
@@ -1,0 +1,50 @@
+import { expect } from 'chai';
+import * as Sinon from 'sinon';
+import { getMoliDebugParameter } from './logging';
+import { createDom } from '../stubs/browserEnvSetup';
+import { googletag } from '../types/googletag';
+import { apstag } from '../types/apstag';
+import { prebidjs } from '../types/prebidjs';
+import { tcfapi } from '../types/tcfapi';
+
+describe('logging', () => {
+  // single sandbox instance to create spies and stubs
+  const sandbox = Sinon.createSandbox();
+
+  const dom = createDom();
+  const jsDomWindow: Window &
+    googletag.IGoogleTagWindow &
+    apstag.WindowA9 &
+    prebidjs.IPrebidjsWindow &
+    tcfapi.TCFApiWindow = dom.window as any;
+
+  beforeEach(() => {
+    // bring everything back to normal after tests
+    sandbox.restore();
+    jsDomWindow.sessionStorage.clear();
+    jsDomWindow.localStorage.clear();
+  });
+
+  describe('getMoliDebugParameter', () => {
+    it('should return false as default', () => {
+      expect(getMoliDebugParameter(jsDomWindow)).to.be.false;
+    });
+
+    it('should return true if moliDebug query param is set', () => {
+      dom.reconfigure({
+        url: 'https://localhost?moliDebug=true'
+      });
+      expect(getMoliDebugParameter(jsDomWindow)).to.be.true;
+    });
+
+    it('should return true if moliDebug is present as session storage', () => {
+      jsDomWindow.sessionStorage.setItem('moliDebug', 'irrelevant');
+      expect(getMoliDebugParameter(jsDomWindow)).to.be.true;
+    });
+
+    it('should return true if moliDebug is present as locale storage', () => {
+      jsDomWindow.localStorage.setItem('moliDebug', 'irrelevant');
+      expect(getMoliDebugParameter(jsDomWindow)).to.be.true;
+    });
+  });
+});

--- a/ad-tag/source/ts/util/logging.ts
+++ b/ad-tag/source/ts/util/logging.ts
@@ -4,13 +4,24 @@ import { Moli } from '../types/moli';
 /**
  * Get the parameter `moliDebug`. If set to true all logs will be written to the console.
  *
+ * The value can be set either
+ *
+ * - as a query parameter: `moliDebug=true`
+ * - as a session storage key
+ * - as a local storage key
  */
-function getMoliDebugParameter(window: Window): boolean {
-  const key = 'moliDebug';
-  const params = parseQueryString(window.location.search);
-  const param = params.get(key);
-
-  return param ? param.toLowerCase() === 'true' : false;
+export function getMoliDebugParameter(window: Window): boolean {
+  try {
+    const key = 'moliDebug';
+    const params = parseQueryString(window.location.search);
+    return (
+      !!params.get(key) ||
+      !!window.sessionStorage.getItem(key) ||
+      !!window.localStorage.getItem(key)
+    );
+  } catch (_) {
+    return false;
+  }
 }
 
 /**


### PR DESCRIPTION
debug logging can now be enabled via

- query parameter `moliDebug=true`
- session or local storage if `moliDebug` key is available