### PR TITLE
Support href validations in SPA for requestAds as well

### DIFF
--- a/ad-tag/source/ts/ads/spa.test.ts
+++ b/ad-tag/source/ts/ads/spa.test.ts
@@ -2,71 +2,116 @@ import { expect, use } from 'chai';
 import sinonChai from 'sinon-chai';
 import chaiAsPromised from 'chai-as-promised';
 import * as Sinon from 'sinon';
-import { allowRefreshAdSlots } from './spa';
+import { allowRefreshAdSlot, allowRequestAds } from './spa';
 
 // setup sinon-chai
 use(sinonChai);
 use(chaiAsPromised);
 
 describe('spa', () => {
-  describe('allowRefreshAdSlots', () => {
-    /* create a fake location for testing. add properties as needed  */
-    const fakeLocation = (href: string): Location => {
-      const location = new URL(href);
-      return {
-        href: href,
-        pathname: location.pathname,
-        host: location.host
-      } as any;
-    };
-
+  /* create a fake location for testing. add properties as needed  */
+  const fakeLocation = (href: string): Location => {
+    const location = new URL(href);
+    return {
+      href: href,
+      pathname: location.pathname,
+      host: location.host
+    } as any;
+  };
+  describe('allowRefreshOrRequestAds', () => {
     describe('validateLocation is none', () => {
       it('should return true when validateLocation is none and href is identical', () => {
         const stateHref = 'https://example.com';
-        expect(allowRefreshAdSlots('none', stateHref, fakeLocation(stateHref))).to.be.true;
+        expect(allowRefreshAdSlot('none', stateHref, fakeLocation(stateHref))).to.be.true;
       });
 
       it('should return true when validateLocation is none and hrefs differ', () => {
         const stateHref1 = 'https://example.com/path/1';
         const stateHref2 = 'https://example.com/path/2';
-        expect(allowRefreshAdSlots('none', stateHref1, fakeLocation(stateHref2))).to.be.true;
+        expect(allowRefreshAdSlot('none', stateHref1, fakeLocation(stateHref2))).to.be.true;
       });
     });
     describe('validateLocation is href', () => {
       it('should return true when validateLocation is href and href is identical', () => {
         const stateHref = 'https://example.com';
-        expect(allowRefreshAdSlots('href', stateHref, fakeLocation(stateHref))).to.be.true;
+        expect(allowRefreshAdSlot('href', stateHref, fakeLocation(stateHref))).to.be.true;
       });
 
       it('should return false when validateLocation is href and hrefs differ', () => {
         const stateHref1 = 'https://example.com/path/1';
         const stateHref2 = 'https://example.com/path/2';
-        expect(allowRefreshAdSlots('href', stateHref1, fakeLocation(stateHref2))).to.be.false;
+        expect(allowRefreshAdSlot('href', stateHref1, fakeLocation(stateHref2))).to.be.false;
       });
     });
 
     describe('validateLocation is path', () => {
       it('should return true when validateLocation is path and paths are identical', () => {
         const stateHref = 'https://example.com/path/1';
-        expect(allowRefreshAdSlots('path', stateHref, fakeLocation(stateHref))).to.be.true;
+        expect(allowRefreshAdSlot('path', stateHref, fakeLocation(stateHref))).to.be.true;
       });
 
       it('should return true when validateLocation is path and paths are identical with different query params', () => {
         const stateHref1 = 'https://example.com/path/1?foo=bar';
         const stateHref2 = 'https://example.com/path/1?foo=baz';
-        expect(allowRefreshAdSlots('path', stateHref1, fakeLocation(stateHref2))).to.be.true;
+        expect(allowRefreshAdSlot('path', stateHref1, fakeLocation(stateHref2))).to.be.true;
       });
 
       it('should return false when validateLocation is path and paths differ', () => {
         const stateHref1 = 'https://example.com/path/1';
         const stateHref2 = 'https://example.com/path/2';
-        expect(allowRefreshAdSlots('path', stateHref1, fakeLocation(stateHref2))).to.be.false;
+        expect(allowRefreshAdSlot('path', stateHref1, fakeLocation(stateHref2))).to.be.false;
       });
 
       it('should return true when validateLocation is path and the href is an invalid url', () => {
         const stateHref: any = null;
-        expect(allowRefreshAdSlots('path', stateHref, fakeLocation('https://example.com'))).to.be
+        expect(allowRefreshAdSlot('path', stateHref, fakeLocation('https://example.com'))).to.be
           .true;
+      });
+    });
+  });
+
+  describe('allowRequestAds', () => {
+    describe('validateLocation is none', () => {
+      it('should return true when validateLocation is none and href is identical', () => {
+        const stateHref = 'https://example.com';
+        expect(allowRequestAds('none', stateHref, fakeLocation(stateHref))).to.be.true;
+      });
+
+      it('should return true when validateLocation is none and hrefs differ', () => {
+        const stateHref1 = 'https://example.com/path/1';
+        const stateHref2 = 'https://example.com/path/2';
+        expect(allowRequestAds('none', stateHref1, fakeLocation(stateHref2))).to.be.true;
+      });
+    });
+    describe('validateLocation is href', () => {
+      it('should return false when validateLocation is href and href is identical', () => {
+        const stateHref = 'https://example.com';
+        expect(allowRequestAds('href', stateHref, fakeLocation(stateHref))).to.be.false;
+      });
+
+      it('should return true when validateLocation is href and hrefs differ', () => {
+        const stateHref1 = 'https://example.com/path/1';
+        const stateHref2 = 'https://example.com/path/2';
+        expect(allowRequestAds('href', stateHref1, fakeLocation(stateHref2))).to.be.true;
+      });
+    });
+
+    describe('validateLocation is path', () => {
+      it('should return false when validateLocation is path and paths are identical', () => {
+        const stateHref = 'https://example.com/path/1';
+        expect(allowRequestAds('path', stateHref, fakeLocation(stateHref))).to.be.false;
+      });
+
+      it('should return false when validateLocation is path and paths are identical with different query params', () => {
+        const stateHref1 = 'https://example.com/path/1?foo=bar';
+        const stateHref2 = 'https://example.com/path/1?foo=baz';
+        expect(allowRequestAds('path', stateHref1, fakeLocation(stateHref2))).to.be.false;
+      });
+
+      it('should return true when validateLocation is path and paths differ', () => {
+        const stateHref1 = 'https://example.com/path/1';
+        const stateHref2 = 'https://example.com/path/2';
+        expect(allowRequestAds('path', stateHref1, fakeLocation(stateHref2))).to.be.true;
       });
     });
   });

--- a/ad-tag/source/ts/ads/spa.ts
+++ b/ad-tag/source/ts/ads/spa.ts
@@ -3,11 +3,11 @@ import { Moli } from '../types/moli';
 /**
  * Check if the refresh of ad slots is allowed based on the validateLocation setting.
  *
- * @param validateLocation confiugred by publisher how users should be validated
+ * @param validateLocation configured by publisher how users should be validated
  * @param stateHref the previous href stored in ad tag state
  * @param currentLocation passed in via `window.location`
  */
-export const allowRefreshAdSlots = (
+export const allowRefreshAdSlot = (
   validateLocation: Moli.SinglePageAppConfig['validateLocation'],
   stateHref: string,
   currentLocation: Location
@@ -21,6 +21,33 @@ export const allowRefreshAdSlots = (
       try {
         const url = new URL(stateHref);
         return currentLocation.pathname === url.pathname;
+      } catch (e) {
+        return true;
+      }
+  }
+};
+
+/**
+ * Check if requestAds may be called.
+ *
+ * @param validateLocation configured by publisher how users should be validated
+ * @param stateHref the previous href stored in ad tag state
+ * @param currentLocation passed in via `window.location`
+ */
+export const allowRequestAds = (
+  validateLocation: Moli.SinglePageAppConfig['validateLocation'],
+  stateHref: string,
+  currentLocation: Location
+): boolean => {
+  switch (validateLocation) {
+    case 'none':
+      return true;
+    case 'href':
+      return currentLocation.href !== stateHref;
+    case 'path':
+      try {
+        const url = new URL(stateHref);
+        return currentLocation.pathname !== url.pathname;
       } catch (e) {
         return true;
       }


### PR DESCRIPTION
This is a potential dangerous features as it allows arbitrarily resetting the internal state of the ad tag if a publisher is not careful enough.