### PR TITLE
Don't wait for ad render to apply css when navbar is not in viewport

### DIFF
--- a/examples/publisher/demo/index.hbs
+++ b/examples/publisher/demo/index.hbs
@@ -9,90 +9,22 @@
 
   {{> partials/head }}
 
-  <!-- sourcepoint stub -->
-  <script type="text/javascript">
-    //@formatter:off
-    !function () { var e = function () { var e, t = "__tcfapiLocator", a = [], n = window; for (; n;) { try { if (n.frames[t]) { e = n; break } } catch (e) { } if (n === window.top) break; n = n.parent } e || (!function e() { var a = n.document, r = !!n.frames[t]; if (!r) if (a.body) { var i = a.createElement("iframe"); i.style.cssText = "display:none", i.name = t, a.body.appendChild(i) } else setTimeout(e, 5); return !r }(), n.__tcfapi = function () { for (var e, t = arguments.length, n = new Array(t), r = 0; r < t; r++)n[r] = arguments[r]; if (!n.length) return a; if ("setGdprApplies" === n[0]) n.length > 3 && 2 === parseInt(n[1], 10) && "boolean" == typeof n[3] && (e = n[3], "function" == typeof n[2] && n[2]("set", !0)); else if ("ping" === n[0]) { var i = { gdprApplies: e, cmpLoaded: !1, cmpStatus: "stub" }; "function" == typeof n[2] && n[2](i) } else a.push(n) }, n.addEventListener("message", (function (e) { var t = "string" == typeof e.data, a = {}; try { a = t ? JSON.parse(e.data) : e.data } catch (e) { } var n = a.__tcfapiCall; n && window.__tcfapi(n.command, n.version, (function (a, r) { var i = { __tcfapiReturn: { returnValue: a, success: r, callId: n.callId } }; t && (i = JSON.stringify(i)), e.source.postMessage(i, "*") }), n.parameter) }), !1)) }; "undefined" != typeof module ? module.exports = e : e() }();
-    //@formatter:on
-  </script>
-  <script>
-    window._sp_ = {
-      config: {
-        accountId: 270,
-        baseEndpoint: 'https://cdn.privacy-mgmt.com',
-        propertyHref: 'https://local.h5v.eu',
-        gdpr: { }
-      }
-    }
-  </script>
-  <script async src="https://cdn.privacy-mgmt.com/unified/wrapperMessagingWithoutDetection.js"></script>
+  <script>if(!("gdprAppliesGlobally" in window)){window.gdprAppliesGlobally=true}if(!("cmp_id" in window)||window.cmp_id<1){window.cmp_id=0}if(!("cmp_cdid" in window)){window.cmp_cdid="3ad82b577101d"}if(!("cmp_params" in window)){window.cmp_params=""}if(!("cmp_host" in window)){window.cmp_host="b.delivery.consentmanager.net"}if(!("cmp_cdn" in window)){window.cmp_cdn="cdn.consentmanager.net"}if(!("cmp_proto" in window)){window.cmp_proto="https:"}if(!("cmp_codesrc" in window)){window.cmp_codesrc="0"}window.cmp_getsupportedLangs=function(){var b=["DE","EN","FR","IT","NO","DA","FI","ES","PT","RO","BG","ET","EL","GA","HR","LV","LT","MT","NL","PL","SV","SK","SL","CS","HU","RU","SR","ZH","TR","UK","AR","BS"];if("cmp_customlanguages" in window){for(var a=0;a<window.cmp_customlanguages.length;a++){b.push(window.cmp_customlanguages[a].l.toUpperCase())}}return b};window.cmp_getRTLLangs=function(){var a=["AR"];if("cmp_customlanguages" in window){for(var b=0;b<window.cmp_customlanguages.length;b++){if("r" in window.cmp_customlanguages[b]&&window.cmp_customlanguages[b].r){a.push(window.cmp_customlanguages[b].l)}}}return a};window.cmp_getlang=function(a){if(typeof(a)!="boolean"){a=true}if(a&&typeof(cmp_getlang.usedlang)=="string"&&cmp_getlang.usedlang!==""){return cmp_getlang.usedlang}return window.cmp_getlangs()[0]};window.cmp_extractlang=function(a){if(a.indexOf("cmplang=")!=-1){a=a.substr(a.indexOf("cmplang=")+8,2).toUpperCase();if(a.indexOf("&")!=-1){a=a.substr(0,a.indexOf("&"))}}else{a=""}return a};window.cmp_getlangs=function(){var g=window.cmp_getsupportedLangs();var c=[];var f=location.hash;var e=location.search;var j="cmp_params" in window?window.cmp_params:"";var a="languages" in navigator?navigator.languages:[];if(cmp_extractlang(f)!=""){c.push(cmp_extractlang(f))}else{if(cmp_extractlang(e)!=""){c.push(cmp_extractlang(e))}else{if(cmp_extractlang(j)!=""){c.push(cmp_extractlang(j))}else{if("cmp_setlang" in window&&window.cmp_setlang!=""){c.push(window.cmp_setlang.toUpperCase())}else{if("cmp_langdetect" in window&&window.cmp_langdetect==1){c.push(window.cmp_getPageLang())}else{if(a.length>0){for(var d=0;d<a.length;d++){c.push(a[d])}}if("language" in navigator){c.push(navigator.language)}if("userLanguage" in navigator){c.push(navigator.userLanguage)}}}}}}var h=[];for(var d=0;d<c.length;d++){var b=c[d].toUpperCase();if(b.length<2){continue}if(g.indexOf(b)!=-1){h.push(b)}else{if(b.indexOf("-")!=-1){b=b.substr(0,2)}if(g.indexOf(b)!=-1){h.push(b)}}}if(h.length==0&&typeof(cmp_getlang.defaultlang)=="string"&&cmp_getlang.defaultlang!==""){return[cmp_getlang.defaultlang.toUpperCase()]}else{return h.length>0?h:["EN"]}};window.cmp_getPageLangs=function(){var a=window.cmp_getXMLLang();if(a!=""){a=[a.toUpperCase()]}else{a=[]}a=a.concat(window.cmp_getLangsFromURL());return a.length>0?a:["EN"]};window.cmp_getPageLang=function(){var a=window.cmp_getPageLangs();return a.length>0?a[0]:""};window.cmp_getLangsFromURL=function(){var c=window.cmp_getsupportedLangs();var b=location;var m="toUpperCase";var g=b.hostname[m]()+".";var a=b.pathname[m]()+"/";var f=[];for(var e=0;e<c.length;e++){var j=a.substring(0,c[e].length+1);if(g.substring(0,c[e].length+1)==c[e]+"."){f.push(c[e][m]())}else{if(c[e].length==5){var k=c[e].substring(3,5)+"-"+c[e].substring(0,2);if(g.substring(0,k.length+1)==k+"."){f.push(c[e][m]())}}else{if(j==c[e]+"/"||j=="/"+c[e]){f.push(c[e][m]())}else{if(j==c[e].replace("-","/")+"/"||j=="/"+c[e].replace("-","/")){f.push(c[e][m]())}else{if(c[e].length==5){var k=c[e].substring(3,5)+"-"+c[e].substring(0,2);var h=a.substring(0,k.length+1);if(h==k+"/"||h==k.replace("-","/")+"/"){f.push(c[e][m]())}}}}}}}return f};window.cmp_getXMLLang=function(){var c=document.getElementsByTagName("html");if(c.length>0){var c=c[0]}else{c=document.documentElement}if(c&&c.getAttribute){var a=c.getAttribute("xml:lang");if(typeof(a)!="string"||a==""){a=c.getAttribute("lang")}if(typeof(a)=="string"&&a!=""){var b=window.cmp_getsupportedLangs();return b.indexOf(a.toUpperCase())!=-1||b.indexOf(a.substr(0,2).toUpperCase())!=-1?a:""}else{return""}}};(function(){var B=document;var C=B.getElementsByTagName;var o=window;var t="";var h="";var k="";var D=function(e){var i="cmp_"+e;e="cmp"+e+"=";var d="";var l=e.length;var G=location;var H=G.hash;var w=G.search;var u=H.indexOf(e);var F=w.indexOf(e);if(u!=-1){d=H.substring(u+l,9999)}else{if(F!=-1){d=w.substring(F+l,9999)}else{return i in o&&typeof(o[i])!=="function"?o[i]:""}}var E=d.indexOf("&");if(E!=-1){d=d.substring(0,E)}return d};var j=D("lang");if(j!=""){t=j;k=t}else{if("cmp_getlang" in o){t=o.cmp_getlang().toLowerCase();h=o.cmp_getlangs().slice(0,3).join("_");k=o.cmp_getPageLangs().slice(0,3).join("_");if("cmp_customlanguages" in o){var m=o.cmp_customlanguages;for(var x=0;x<m.length;x++){var a=m[x].l.toLowerCase();if(a==t){t="en"}}}}}var q=("cmp_proto" in o)?o.cmp_proto:"https:";if(q!="http:"&&q!="https:"){q="https:"}var n=("cmp_ref" in o)?o.cmp_ref:location.href;if(n.length>300){n=n.substring(0,300)}var z=function(d){var I=B.createElement("script");I.setAttribute("data-cmp-ab","1");I.type="text/javascript";I.async=true;I.src=d;var H=["body","div","span","script","head"];var w="currentScript";var F="parentElement";var l="appendChild";var G="body";if(B[w]&&B[w][F]){B[w][F][l](I)}else{if(B[G]){B[G][l](I)}else{for(var u=0;u<H.length;u++){var E=C(H[u]);if(E.length>0){E[0][l](I);break}}}}};var b=D("design");var c=D("regulationkey");var y=D("gppkey");var s=D("att");var f=o.encodeURIComponent;var g=false;try{g=B.cookie.length>0}catch(A){g=false}var p=q+"//"+o.cmp_host+"/delivery/cmp.php?";p+=("cmp_id" in o&&o.cmp_id>0?"id="+o.cmp_id:"")+("cmp_cdid" in o?"&cdid="+o.cmp_cdid:"")+"&h="+f(n);p+=(b!=""?"&cmpdesign="+f(b):"")+(c!=""?"&cmpregulationkey="+f(c):"")+(y!=""?"&cmpgppkey="+f(y):"");p+=(s!=""?"&cmpatt="+f(s):"")+("cmp_params" in o?"&"+o.cmp_params:"")+(g?"&__cmpfcc=1":"");z(p+"&l="+f(t)+"&ls="+f(h)+"&lp="+f(k)+"&o="+(new Date()).getTime());var r="js";var v=D("debugunminimized")!=""?"":".min";if(D("debugcoverage")=="1"){r="instrumented";v=""}if(D("debugtest")=="1"){r="jstests";v=""}z(q+"//"+o.cmp_cdn+"/delivery/"+r+"/cmp_final"+v+".js")})();window.cmp_addFrame=function(b){if(!window.frames[b]){if(document.body){var a=document.createElement("iframe");a.style.cssText="display:none";if("cmp_cdn" in window&&"cmp_ultrablocking" in window&&window.cmp_ultrablocking>0){a.src="//"+window.cmp_cdn+"/delivery/empty.html"}a.name=b;a.setAttribute("title","Intentionally hidden, please ignore");a.setAttribute("role","none");a.setAttribute("tabindex","-1");document.body.appendChild(a)}else{window.setTimeout(window.cmp_addFrame,10,b)}}};window.cmp_rc=function(c,b){var l="";try{l=document.cookie}catch(h){l=""}var j="";var f=0;var g=false;while(l!=""&&f<100){f++;while(l.substr(0,1)==" "){l=l.substr(1,l.length)}var k=l.substring(0,l.indexOf("="));if(l.indexOf(";")!=-1){var m=l.substring(l.indexOf("=")+1,l.indexOf(";"))}else{var m=l.substr(l.indexOf("=")+1,l.length)}if(c==k){j=m;g=true}var d=l.indexOf(";")+1;if(d==0){d=l.length}l=l.substring(d,l.length)}if(!g&&typeof(b)=="string"){j=b}return(j)};window.cmp_stub=function(){var a=arguments;__cmp.a=__cmp.a||[];if(!a.length){return __cmp.a}else{if(a[0]==="ping"){if(a[1]===2){a[2]({gdprApplies:gdprAppliesGlobally,cmpLoaded:false,cmpStatus:"stub",displayStatus:"hidden",apiVersion:"2.2",cmpId:31},true)}else{a[2](false,true)}}else{if(a[0]==="getUSPData"){a[2]({version:1,uspString:window.cmp_rc("__cmpccpausps","1---")},true)}else{if(a[0]==="getTCData"){__cmp.a.push([].slice.apply(a))}else{if(a[0]==="addEventListener"||a[0]==="removeEventListener"){__cmp.a.push([].slice.apply(a))}else{if(a.length==4&&a[3]===false){a[2]({},false)}else{__cmp.a.push([].slice.apply(a))}}}}}}};window.cmp_gpp_ping=function(){return{gppVersion:"1.1",cmpStatus:"stub",cmpDisplayStatus:"hidden",signalStatus:"not ready",supportedAPIs:["2:tcfeuv2","5:tcfcav1","7:usnat","8:usca","9:usva","10:usco","11:usut","12:usct"],cmpId:31,sectionList:[],applicableSections:[0],gppString:"",parsedSections:{}}};window.cmp_dsastub=function(){var a=arguments;a[0]="dsa."+a[0];window.cmp_gppstub(a)};window.cmp_gppstub=function(){var c=arguments;__gpp.q=__gpp.q||[];if(!c.length){return __gpp.q}var h=c[0];var g=c.length>1?c[1]:null;var f=c.length>2?c[2]:null;var a=null;var j=false;if(h==="ping"){a=window.cmp_gpp_ping();j=true}else{if(h==="addEventListener"){__gpp.e=__gpp.e||[];if(!("lastId" in __gpp)){__gpp.lastId=0}__gpp.lastId++;var d=__gpp.lastId;__gpp.e.push({id:d,callback:g});a={eventName:"listenerRegistered",listenerId:d,data:true,pingData:window.cmp_gpp_ping()};j=true}else{if(h==="removeEventListener"){__gpp.e=__gpp.e||[];a=false;for(var e=0;e<__gpp.e.length;e++){if(__gpp.e[e].id==f){__gpp.e[e].splice(e,1);a=true;break}}j=true}else{__gpp.q.push([].slice.apply(c))}}}if(a!==null&&typeof(g)==="function"){g(a,j)}};window.cmp_msghandler=function(d){var a=typeof d.data==="string";try{var c=a?JSON.parse(d.data):d.data}catch(f){var c=null}if(typeof(c)==="object"&&c!==null&&"__cmpCall" in c){var b=c.__cmpCall;window.__cmp(b.command,b.parameter,function(h,g){var e={__cmpReturn:{returnValue:h,success:g,callId:b.callId}};d.source.postMessage(a?JSON.stringify(e):e,"*")})}if(typeof(c)==="object"&&c!==null&&"__uspapiCall" in c){var b=c.__uspapiCall;window.__uspapi(b.command,b.version,function(h,g){var e={__uspapiReturn:{returnValue:h,success:g,callId:b.callId}};d.source.postMessage(a?JSON.stringify(e):e,"*")})}if(typeof(c)==="object"&&c!==null&&"__tcfapiCall" in c){var b=c.__tcfapiCall;window.__tcfapi(b.command,b.version,function(h,g){var e={__tcfapiReturn:{returnValue:h,success:g,callId:b.callId}};d.source.postMessage(a?JSON.stringify(e):e,"*")},b.parameter)}if(typeof(c)==="object"&&c!==null&&"__gppCall" in c){var b=c.__gppCall;window.__gpp(b.command,function(h,g){var e={__gppReturn:{returnValue:h,success:g,callId:b.callId}};d.source.postMessage(a?JSON.stringify(e):e,"*")},"parameter" in b?b.parameter:null,"version" in b?b.version:1)}if(typeof(c)==="object"&&c!==null&&"__dsaCall" in c){var b=c.__dsaCall;window.__dsa(b.command,function(h,g){var e={__dsaReturn:{returnValue:h,success:g,callId:b.callId}};d.source.postMessage(a?JSON.stringify(e):e,"*")},"parameter" in b?b.parameter:null,"version" in b?b.version:1)}};window.cmp_setStub=function(a){if(!(a in window)||(typeof(window[a])!=="function"&&typeof(window[a])!=="object"&&(typeof(window[a])==="undefined"||window[a]!==null))){window[a]=window.cmp_stub;window[a].msgHandler=window.cmp_msghandler;window.addEventListener("message",window.cmp_msghandler,false)}};window.cmp_setGppStub=function(a){if(!(a in window)||(typeof(window[a])!=="function"&&typeof(window[a])!=="object"&&(typeof(window[a])==="undefined"||window[a]!==null))){window[a]=window.cmp_gppstub;window[a].msgHandler=window.cmp_msghandler;window.addEventListener("message",window.cmp_msghandler,false)}};if(!("cmp_noiframepixel" in window)){window.cmp_addFrame("__cmpLocator")}if((!("cmp_disableusp" in window)||!window.cmp_disableusp)&&!("cmp_noiframepixel" in window)){window.cmp_addFrame("__uspapiLocator")}if((!("cmp_disabletcf" in window)||!window.cmp_disabletcf)&&!("cmp_noiframepixel" in window)){window.cmp_addFrame("__tcfapiLocator")}if((!("cmp_disablegpp" in window)||!window.cmp_disablegpp)&&!("cmp_noiframepixel" in window)){window.cmp_addFrame("__gppLocator")}if((!("cmp_disabledsa" in window)||!window.cmp_disabledsa)&&!("cmp_noiframepixel" in window)){window.cmp_addFrame("__dsaLocator")}window.cmp_setStub("__cmp");if(!("cmp_disabletcf" in window)||!window.cmp_disabletcf){window.cmp_setStub("__tcfapi")}if(!("cmp_disableusp" in window)||!window.cmp_disableusp){window.cmp_setStub("__uspapi")}if(!("cmp_disablegpp" in window)||!window.cmp_disablegpp){window.cmp_setGppStub("__gpp")}if(!("cmp_disabledsa" in window)||!window.cmp_disabledsa){window.cmp_setGppStub("__dsa")};</script>
 
   <style>
     body {
       display: flex;
+      flex-direction: column;
     }
 
     .u-mtm {
       margin-top: 1rem;
     }
   </style>
+  <link rel="stylesheet" href="https://highfivve.github.io/footer-ads/header-sticky-nosticky-navbar/sticky-ad.css">
 
   <!-- mobile sticky ad -->
-  <style>
-    .h5-sticky-ad {
-      background-color: #f3f3f3;
-      border: none;
-      bottom: 0;
-      box-shadow: 0 -1px 1px 0 rgba(0, 0, 0, 0.2);
-      height: 59px;
-      left: 0;
-      padding: 5px;
-      position: fixed;
-      text-align: center;
-      width: 100%;
-      z-index: 900; /* set this to a value that enables the sticky ad to overlap any other elements on the page. */
-    }
-
-    .h5-sticky-ad-close {
-      background-color: #f3f3f3;
-      background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg width='13' height='13' viewBox='341 8 13 13' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill='%234F4F4F' d='M354 9.31L352.69 8l-5.19 5.19L342.31 8 341 9.31l5.19 5.19-5.19 5.19 1.31 1.31 5.19-5.19 5.19 5.19 1.31-1.31-5.19-5.19z' fill-rule='evenodd'/%3E%3C/svg%3E");
-      background-position: 9px;
-      background-repeat: no-repeat;
-      background-size: 13px 13px;
-      border: none;
-      border-top-left-radius: 12px;
-      box-shadow: 0 -1px 1px 0 rgba(0, 0, 0, 0.2);
-      height: 28px;
-      padding: 6px;
-      position: absolute;
-      right: 0;
-      top: -28px;
-      width: 28px;
-    }
-
-    .h5-sticky-ad-close::before {
-      bottom: 0;
-      content: "";
-      left: -20px;
-      position: absolute;
-      right: 0;
-      top: -20px;
-    }
-
-    .u-visible-desktop {
-      display: none;
-    }
-
-    @media (min-width: 768px) {
-      .u-hidden-desktop {
-        display: none;
-      }
-
-      .u-visible-desktop {
-        display: block;
-      }
-    }
-  </style>
+  <link rel="stylesheet" href="https://highfivve.github.io/footer-ads/mobile-sticky/sticky-ad.css">
 
   <!-- floor ad -->
   <style>
@@ -249,6 +181,12 @@
 </script>
 
 <body>
+<nav class="navbar navbar-light bg-light">
+  <a class="navbar-brand" href="#">Navbar</a>
+</nav>
+<div class="header-ad" data-ref="header-ad">
+  <div id="ad-header" style="background: #eef0f2"></div>
+</div>
 <div class="container-fluid">
   <div class="jumbotron">
     <h1 class="display-4">
@@ -426,6 +364,7 @@
     excepturi expedita fugiat harum hic, inventore laudantium, magni maxime modi mollitia neque nisi officia perferendis
     ratione recusandae reprehenderit repudiandae saepe sequi suscipit tenetur velit voluptas voluptatum.</p>
 
+  <div id="fadeOut--trigger">fade out for sticky header</div>
   <div class="row">
     <div class="col-md">
       <h1>Infinite Ad Slot 2</h1>

--- a/examples/publisher/index.ts
+++ b/examples/publisher/index.ts
@@ -29,6 +29,7 @@ import 'prebid.js/modules/userId/index';
 import 'prebid.js/modules/unifiedIdSystem';
 import 'prebid.js/modules/rubiconBidAdapter';
 import 'prebid.js/modules/priceFloors';
+import { StickyHeaderAds } from '@highfivve/module-sticky-header-ads';
 
 prebid.processQueue();
 
@@ -146,6 +147,23 @@ moli.registerModule(
       // gutefrage-intern
     ],
     closingButtonText: 'schließen'
+  })
+);
+
+moli.registerModule(
+  new StickyHeaderAds({
+    headerAdDomId: 'ad-header',
+    navbarConfig: {
+      selector: 'nav',
+      navbarHiddenClassName: 'header-ad--navbarHidden'
+    },
+    fadeOutTrigger: {
+      selector: '#fadeOut--trigger'
+    },
+    fadeOutClassName: 'header-ad--fadeOut',
+    disallowedAdvertiserIds: [],
+    waitForRendering: true,
+    minVisibleDurationMs: 1500
   })
 );
 

--- a/examples/publisher/source/ts/configuration.ts
+++ b/examples/publisher/source/ts/configuration.ts
@@ -134,6 +134,37 @@ export const adConfiguration = (moliVersion: string): Moli.MoliConfig => ({
   domain: 'gutefrage.net',
   slots: [
     {
+      domId: 'ad-header',
+      position: 'in-page',
+      labelAny: ['mobile', 'desktop'],
+      adUnitPath: '/55155651/prebid_test/ad-header/{device}/{domain}',
+      sizes: [
+        [320, 100],
+        [300, 100],
+        [728, 90]
+      ],
+      sizeConfig: [
+        {
+          mediaQuery: '(max-width: 767px)',
+          sizesSupported: [
+            [320, 100],
+            [300, 100]
+          ]
+        },
+        {
+          mediaQuery: '(min-width: 768px)',
+          sizesSupported: [[728, 90]]
+        }
+      ],
+      behaviour: {
+        loaded: 'eager'
+      },
+      gpt: {
+        // prevent collapsing this div because it hurts the CLS score
+        collapseEmptyDiv: false
+      }
+    },
+    {
       domId: 'ad-content-1',
       position: 'in-page',
       labelAny: ['mobile', 'desktop'],

--- a/examples/single-page-app/index.ts
+++ b/examples/single-page-app/index.ts
@@ -22,9 +22,6 @@ moli.beforeRequestAds(_ => {
   console.log('BEFORE REQUEST ADS HOOK');
 });
 
-moli.enableSinglePageApp();
-// init moli
-
 moli.registerModule(
   new LazyLoad(
     {

--- a/examples/single-page-app/source/ts/configuration.ts
+++ b/examples/single-page-app/source/ts/configuration.ts
@@ -3,6 +3,7 @@ import video = prebidjs.video;
 
 export const adConfiguration: Moli.MoliConfig = {
   environment: 'test',
+  spa: { enabled: true, validateLocation: 'href' },
   slots: [
     {
       position: 'in-page',

--- a/modules/sticky-header-ads/index.ts
+++ b/modules/sticky-header-ads/index.ts
@@ -280,24 +280,25 @@ export class StickyHeaderAds implements IModule {
             : null;
 
           const callback: IntersectionObserverCallback = entries => {
-            adRenderIsEmpty.then(isEmpty => {
-              // only one element will be observed
-              const entry = entries[0];
-
+            // initially there maybe two events, for navbar and the target element
+            entries.forEach(entry => {
               // fadeout the ad if the observed element is the target
               if (entry.target === target) {
-                if (
-                  // user scrolls down
-                  entry.isIntersecting ||
-                  // user starts below observed DOM
-                  (!entry.isIntersecting && entry.boundingClientRect.y < 0) ||
-                  // if the ad is empty, hide it
-                  isEmpty
-                ) {
-                  container.classList.add(this.stickyHeaderAdConfig.fadeOutClassName);
-                } else if (entry.boundingClientRect.y >= 0 && !isEmpty) {
-                  container.classList.remove(this.stickyHeaderAdConfig.fadeOutClassName);
-                }
+                // wait for the ad to be rendered before hiding it
+                adRenderIsEmpty.then(isEmpty => {
+                  if (
+                    // user scrolls down
+                    entry.isIntersecting ||
+                    // user starts below observed DOM
+                    (!entry.isIntersecting && entry.boundingClientRect.y < 0) ||
+                    // if the ad is empty, hide it
+                    isEmpty
+                  ) {
+                    container.classList.add(this.stickyHeaderAdConfig.fadeOutClassName);
+                  } else if (entry.boundingClientRect.y >= 0 && !isEmpty) {
+                    container.classList.remove(this.stickyHeaderAdConfig.fadeOutClassName);
+                  }
+                });
               } else if (entry.target === navbar && navbarHiddenClass) {
                 // apply a separate class if the navbar is not intersecting the viewport anymore
                 if (entry.isIntersecting) {


### PR DESCRIPTION
This fixes two issues

- when the page initially loads somewhere else or the intersection observer is registered later, then all events should be taken into account
- don't wait for the ad to render for the navbar hidden css event