### PR TITLE
Add staging environment that sets a page_url

### DIFF
--- a/ad-tag/source/ts/ads/prebid.ts
+++ b/ad-tag/source/ts/ads/prebid.ts
@@ -514,7 +514,7 @@ export const prebidDefineSlots =
       } as any;
       switch (context.env) {
         case 'production':
-          return Promise.resolve<Moli.SlotDefinition>({ moliSlot, adSlot, filterSupportedSizes });
+        case 'staging':
         case 'test':
           return Promise.resolve<Moli.SlotDefinition>({ moliSlot, adSlot, filterSupportedSizes });
         default:
@@ -535,6 +535,7 @@ export const prebidRenderAds =
             createTestSlots(context, slots);
             break;
           case 'production':
+          case 'staging':
             context.window.pbjs
               .getHighestCpmBids()
               .filter(bid => bid && bid.adId)

--- a/ad-tag/source/ts/types/moli.ts
+++ b/ad-tag/source/ts/types/moli.ts
@@ -45,7 +45,7 @@ export namespace Moli {
    * This environment is recommended for early testing to get some visual feedback.
    *
    */
-  export type Environment = 'production' | 'test';
+  export type Environment = 'production' | 'staging' | 'test';
 
   /**
    * # Moli Ad Tag

--- a/moli-debugger/components/globalConfig.tsx
+++ b/moli-debugger/components/globalConfig.tsx
@@ -213,6 +213,19 @@ export class GlobalConfig
     const switchToDarkTheme = () => this.setTheme('dark');
     const switchToLightTheme = () => this.setTheme('light');
 
+    const EnvironmentTag: React.FC<{ env: Moli.Environment | undefined }> = ({ env }) => {
+      switch (env) {
+        case 'production':
+          return <Tag variant="green">Production</Tag>;
+        case 'staging':
+          return <Tag variant="blue">Staging</Tag>;
+        case 'test':
+          return <Tag variant="yellow">Test</Tag>;
+        default:
+          return <Tag variant="red">Unknown</Tag>;
+      }
+    };
+
     return (
       <>
         <button
@@ -256,11 +269,7 @@ export class GlobalConfig
                 <div>
                   <div className="MoliDebug-tagContainer">
                     <TagLabel>Mode</TagLabel>
-                    {config.environment === 'test' ? (
-                      <Tag variant="yellow">Test</Tag>
-                    ) : (
-                      <Tag variant="green">Production</Tag>
-                    )}
+                    <EnvironmentTag env={config.environment} />
                     {isEnvironmentOverriden ? (
                       <button
                         className="MoliDebug-button MoliDebug-button--green"


### PR DESCRIPTION
This PR adds a first version of a `staging` environment that sets the `page_url` in order to allow GAM to serve ads on none approved domains