### PR TITLE
Add failsafe timeout for prebid auction

### DIFF
--- a/ad-tag/source/ts/types/moli.ts
+++ b/ad-tag/source/ts/types/moli.ts
@@ -1563,6 +1563,19 @@ export namespace Moli {
        */
       readonly ephemeralAdUnits?: boolean;
 
+      /**
+       * A timeout in milliseconds for the prebid auction. If for whatever reason never calls the bidsBackHandler, this
+       * timeout will be used to continue anyway to minimize the revenue impact.
+       *
+       * Note that the max of the auction timeout or failsafeTimeout will be used to avoid misconfiguration.
+       *
+       * The default is chosen to be 2000ms longer than the auction timeout to give the auction a chance to finish.
+       * Usually auction timeouts range from 500ms to 3000ms, which makes 2000ms extra for a failsafe a fair guess.
+       *
+       * @default auction timeout + 2000ms
+       */
+      readonly failsafeTimeout?: number;
+
       /** optional listener for prebid events */
       listener?: PrebidListenerProvider;
     }


### PR DESCRIPTION
Implement what is described here https://docs.prebid.org/features/timeouts.html

> Failsafe Timeout - This is a timeout entirely outside of Prebid.js. It’s a JavaScript setTimeout() that publishers should consider establishing after the Prebid.js code is loaded. It’s a safety net that invokes the ad server callback in case something goes wrong. In all regular scenarios, Prebid.js will have already invoked the callback before this timeout is reached. This value should be much larger than the auction timeout.