### PR TITLE
Preserve 5.x assets during gh-pages deployment

### DIFF
--- a/.github/.clear-target-files
+++ b/.github/.clear-target-files
@@ -1,0 +1,6 @@
+**/*
+!.git
+!assets/bundle/**/*
+!assets/schema/**/*
+# When 5.x is merged, this line must be present in this file to prevent breaking old ad tag versions
+# !assets/js/moli-debug.min.js

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -60,9 +60,12 @@ jobs:
 
       # Deploy website
       - name: Deploy
-        uses: s0/git-publish-subdir-action@develop
+        uses: s0/git-publish-subdir-action@v2.6.0
         env:
           REPO: self
           BRANCH: gh-pages
           FOLDER: website/build
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # this overrides the default clearing behaviour (entire target directory, FOLDER) and allows to keep some files
+          # mainly the moli debugger and prebuilt bundles
+          CLEAR_GLOBS_FILE: .github/.clear-target-files

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ pids
 node_modules
 .idea
 *.iml
+
+# intellij
+.run


### PR DESCRIPTION
There are already assets from the `5.x` branch deployed on the website and we don't want the to be purged, during 4.x website deployments.