### PR TITLE
Support runtime targetings only in theAdex

### DIFF
--- a/ad-tag/source/ts/ads/modules/adex/index.test.ts
+++ b/ad-tag/source/ts/ads/modules/adex/index.test.ts
@@ -227,8 +227,7 @@ describe('The Adex DMP Module', () => {
       };
       const init = module.initSteps()[0];
       expect(init).to.be.ok;
-
-      await expect(init(adPipelineCtx)).to.eventually.be.fulfilled;
+      await init(adPipelineCtx);
 
       expect(jsDomWindow._adexc).to.deep.equal([
         [
@@ -259,8 +258,7 @@ describe('The Adex DMP Module', () => {
       };
       const init = module.initSteps()[0];
       expect(init).to.be.ok;
-
-      await expect(init(adPipelineCtx)).to.eventually.be.fulfilled;
+      await init(adPipelineCtx);
 
       expect(jsDomWindow._adexc).to.deep.equal([
         [
@@ -268,6 +266,35 @@ describe('The Adex DMP Module', () => {
           'ut', // usertrack
           '_kv', // key values
           [{ iab_cat: 'Medical', example_iab_v3: 'example_iab_v3_value_overridden' }, 1]
+        ]
+      ]);
+    });
+
+    it('should set runtime config targeting if no server side targeting is given', async () => {
+      const module = createAndConfigureModule(true, [
+        { key: 'channel', attribute: 'iab_cat', adexValueType: 'string' },
+        { key: 'iab_v3', attribute: 'example_iab_v3', adexValueType: 'string' }
+      ]);
+
+      const adPipelineCtx: AdPipelineContext = {
+        ...adPipelineContext(fullConsent({ '44': true }), undefined),
+        runtimeConfig: {
+          ...emptyRuntimeConfig,
+          keyValues: {
+            iab_v3: 'example_iab_v3_value'
+          }
+        }
+      };
+      const init = module.initSteps()[0];
+      expect(init).to.be.ok;
+      await init(adPipelineCtx);
+
+      expect(jsDomWindow._adexc).to.deep.equal([
+        [
+          `/123/456/`,
+          'ut', // usertrack
+          '_kv', // key values
+          [{ example_iab_v3: 'example_iab_v3_value' }, 1]
         ]
       ]);
     });

--- a/ad-tag/source/ts/ads/modules/adex/index.ts
+++ b/ad-tag/source/ts/ads/modules/adex/index.ts
@@ -310,29 +310,27 @@ export class AdexModule implements IModule {
   };
 
   private configureAdexC = (context: AdPipelineContext, config: modules.adex.AdexConfig) => {
-    if (!context.config.targeting) {
+    const adexKeyValues = this.getAdexKeyValues(context, config);
+    if (!adexKeyValues) {
       context.logger.warn('Adex DMP', 'targeting key/values are empty');
       return Promise.resolve();
     } else {
-      const adexKeyValues = this.getAdexKeyValues(context, config);
-
-      adexKeyValues &&
-        (context.window as ITheAdexWindow)._adexc?.push([
-          `/${config.adexCustomerId}/${config.adexTagId}/`,
-          'ut', // usertrack
-          '_kv', // key values
-          [
-            adexKeyValues.reduce(
-              (
-                aggregator: modules.adex.AdexKeyValues,
-                additionalKeyValue: modules.adex.AdexKeyValues
-              ) => ({ ...aggregator, ...additionalKeyValue }) as modules.adex.AdexKeyValues,
-              {}
-            ),
-            // single page mode for logged-in
-            config.spaMode ? 1 : 0
-          ]
-        ]);
+      (context.window as ITheAdexWindow)._adexc?.push([
+        `/${config.adexCustomerId}/${config.adexTagId}/`,
+        'ut', // usertrack
+        '_kv', // key values
+        [
+          adexKeyValues.reduce(
+            (
+              aggregator: modules.adex.AdexKeyValues,
+              additionalKeyValue: modules.adex.AdexKeyValues
+            ) => ({ ...aggregator, ...additionalKeyValue }) as modules.adex.AdexKeyValues,
+            {}
+          ),
+          // single page mode for logged-in
+          config.spaMode ? 1 : 0
+        ]
+      ]);
     }
   };
 }


### PR DESCRIPTION
There was a check on `config.targeting.keyValues` , which is true if there are no static key-values.
This causes no adex tracking requests, if there are only client (runtime) targetings set via `setTargeting`