### PR TITLE
Add additional tests to label config service

### DIFF
--- a/ad-tag/source/ts/ads/labelConfigService.test.ts
+++ b/ad-tag/source/ts/ads/labelConfigService.test.ts
@@ -65,6 +65,7 @@ describe('LabelConfigConfigService', () => {
   };
 
   const jsDomWindow: Window = dom.window as any;
+  const matchMediaStub = sandbox.stub(jsDomWindow, 'matchMedia');
 
   const newLabelConfigService = (
     labelConfig: sizeConfigs.LabelSizeConfigEntry[],
@@ -81,6 +82,7 @@ describe('LabelConfigConfigService', () => {
 
   describe('slot label matching logic', () => {
     it('should let the given slot pass if label configuration is empty', () => {
+      matchMediaStub.returns({ matches: true } as MediaQueryList);
       const slotPassed = newLabelConfigService([labelConfigEntryWithoutLabels]).filterSlot(
         adSlotWithLabelAll
       );
@@ -89,6 +91,7 @@ describe('LabelConfigConfigService', () => {
     });
 
     it('should filter out duplicate labels from the label config', () => {
+      matchMediaStub.returns({ matches: true } as MediaQueryList);
       const labelConfigService = new LabelConfigService(
         [labelConfigEntry1, labelConfigEntry2],
         [],
@@ -101,6 +104,7 @@ describe('LabelConfigConfigService', () => {
     });
 
     it('should check if given slots with labelAny/labelAll match the configured label criteria', () => {
+      matchMediaStub.returns({ matches: true } as MediaQueryList);
       const sizeConfigService = newLabelConfigService([labelConfigEntry1, labelConfigEntry2]);
       expect(sizeConfigService.getSupportedLabels()).to.deep.equal([
         'desktop',
@@ -158,14 +162,23 @@ describe('LabelConfigConfigService', () => {
   });
 
   describe('extraLabels overriding labelSizeConfig', () => {
-    [
-      { labels: [], deviceLabel: 'desktop' },
+    const inputs = [
       { labels: ['mobile'], deviceLabel: 'mobile' },
       { labels: ['desktop'], deviceLabel: 'desktop' },
       { labels: ['ios'], deviceLabel: 'ios' },
       { labels: ['android', 'test'], deviceLabel: 'android' }
-    ].forEach(({ labels, deviceLabel }) => {
-      it(`should return ${deviceLabel} if labels are [${labels.join(',')}]`, () => {
+    ];
+    inputs.forEach(({ labels, deviceLabel }) => {
+      it(`should return ${deviceLabel} if labels are [${labels.join(',')}] and matchMedia matches:true`, () => {
+        matchMediaStub.returns({ matches: true } as MediaQueryList);
+        const sizeConfigService = newLabelConfigService([labelConfigEntry1], labels);
+        expect(sizeConfigService.getDeviceLabel()).to.be.equals(deviceLabel);
+      });
+    });
+
+    inputs.forEach(({ labels, deviceLabel }) => {
+      it(`should return ${deviceLabel} if labels are [${labels.join(',')}] and matchMedia matches:false`, () => {
+        matchMediaStub.returns({ matches: false } as MediaQueryList);
         const sizeConfigService = newLabelConfigService([labelConfigEntry1], labels);
         expect(sizeConfigService.getDeviceLabel()).to.be.equals(deviceLabel);
       });


### PR DESCRIPTION
Improve tests and coverage for label config service.

It should ensure that publisher device label overrides really, really work.