### PR TITLE
Pass RefreshAdSlot options to refreshBucket API call

### DIFF
--- a/ad-tag/source/ts/ads/moli.ts
+++ b/ad-tag/source/ts/ads/moli.ts
@@ -711,12 +711,17 @@ export const createMoliTag = (window: Window): MoliRuntime.MoliTag => {
     }
   }
 
-  function refreshBucket(bucket: string): Promise<'queued' | 'refreshed'> {
+  function refreshBucket(
+    bucket: string,
+    options?: MoliRuntime.RefreshAdSlotsOptions
+  ): Promise<'queued' | 'refreshed'> {
     // A helper function to retrieve domIds that belong to buckets.
     function getBucketDomIds(config: MoliConfig): string[] {
       const slotsInBucket = config.slots.filter(slot => slot.behaviour.bucket === bucket);
       return slotsInBucket?.map(slot => slot.domId);
     }
+
+    // FIXME the options are not persisted in the state, so they are not used in the refreshBucket call
 
     switch (state.state) {
       case 'configurable': {
@@ -750,7 +755,7 @@ export const createMoliTag = (window: Window): MoliRuntime.MoliTag => {
         if (allowRefreshAdSlot(validateLocation, state.href, window.location)) {
           // user hasn't navigated yet, so we directly refresh the slot
           return adService
-            .refreshBucket(bucket, state.config, state.runtimeConfig)
+            .refreshBucket(bucket, state.config, state.runtimeConfig, options)
             .then(() => 'refreshed');
         } else {
           const domIds = getBucketDomIds(state.config);

--- a/ad-tag/source/ts/types/moliRuntime.ts
+++ b/ad-tag/source/ts/types/moliRuntime.ts
@@ -185,10 +185,22 @@ export namespace MoliRuntime {
      * moli.refreshAdSlots(['content_1', 'content_2']);
      * ```
      *
+     * ## Backfill setups
+     *
      * Refreshing a single ad slot that has loading behaviour `backfill` with custom options.
      *
      * ```javascript
      * moli.refreshAdSlots(['content_1'], { loaded: 'backfill' });
+     * ```
+     *
+     * ## Refresh an eagerly loaded slot
+     *
+     * This is useful if you have a fully rendered page on the server and the ad slot can be eagerly
+     * requested, but the user can alter the page afterwards, e.g. filtering the content or changing the layout and
+     * the slot should be refreshed.
+     *
+     * ```javascript
+     * moli.refreshAdSlots(['content_1'], { loaded: 'eager' });
      * ```
      *
      * @param domId - identifies the ad slot or ad slots
@@ -231,26 +243,18 @@ export namespace MoliRuntime {
     /**
      * Refresh the given bucket as soon as possible.
      *
-     * This is only possible for ad slots with a `manual` loading behaviour and bucket is enabled
+     * By default, this is only possible for ad slots with a `manual` loading behaviour and bucket is enabled.
+     * You need to manually override this through the `options` parameter.
      *
      * Ad slots in buckets are batched until requestAds() is being called. This reduces the amount of requests made to the
      * ad server if the `refreshAdSlot` calls are before the ad tag is loaded.
      *
-     * @param bucket - identifies the bucket
-     */
-    refreshBucket(bucket: string): Promise<'queued' | 'refreshed'>;
-
-    /**
-     * Refresh the given bucket as soon as possible.
-     *
-     * This is only possible for ad slots with a `manual` loading behaviour and bucket is enabled
-     *
-     * Ad slots in buckets are batched until requestAds() is being called. This reduces the amount of requests made to the
-     * ad server if the `refreshAdSlot` calls are before the ad tag is loaded.
+     * See the `refreshAdSlot` method for more information on how to refresh ad slots.
      *
      * @param bucket - identifies the bucket
+     * @param options - optional options to override the default refreshing behaviour
      */
-    refreshBucket(bucket: string): Promise<'queued' | 'refreshed'>;
+    refreshBucket(bucket: string, options?: RefreshAdSlotsOptions): Promise<'queued' | 'refreshed'>;
 
     /**
      * Returns the  current state of the configuration. This configuration may not be final!


### PR DESCRIPTION
The `refreshBucket` call currently does not forward the `options` parameter to the `AdService` as it is simply missing.