### PR TITLE
Add overrides for viewability measurement in ad reload

### DIFF
--- a/ad-tag/source/ts/index.ts
+++ b/ad-tag/source/ts/index.ts
@@ -5,6 +5,7 @@ export * from './types/moli';
 export * from './types/prebidjs';
 export * from './types/tcfapi';
 export * from './types/supplyChainObject';
+export * from './types/dom';
 export * from './ads/moliGlobal';
 export * from './ads/moli';
 export * from './ads/adPipeline';

--- a/ad-tag/source/ts/stubs/intersectionObserverStubs.ts
+++ b/ad-tag/source/ts/stubs/intersectionObserverStubs.ts
@@ -1,0 +1,27 @@
+const MockIntersectionObserver = class MockIntersectionObserver implements IntersectionObserver {
+  readonly root: Element | Document | null = null;
+  readonly rootMargin: string = '0';
+  readonly thresholds: ReadonlyArray<number> = [];
+  constructor(
+    callback?: IntersectionObserverCallback | undefined,
+    options?: IntersectionObserverInit | undefined
+  ) {
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+  }
+  observe() {
+    return;
+  }
+  unobserve() {
+    return;
+  }
+
+  disconnect(): void {
+    return;
+  }
+
+  takeRecords(): IntersectionObserverEntry[] {
+    return [];
+  }
+};
+
+export { MockIntersectionObserver };

--- a/ad-tag/source/ts/types/dom.ts
+++ b/ad-tag/source/ts/types/dom.ts
@@ -1,0 +1,13 @@
+/**
+ * To solve the Intersection Observer API typescript error
+ * @see https://github.com/microsoft/TypeScript/issues/16255
+ */
+export type IntersectionObserverWindow = {
+  IntersectionObserver: {
+    prototype: IntersectionObserver;
+    new (
+      callback: IntersectionObserverCallback,
+      options?: IntersectionObserverInit
+    ): IntersectionObserver;
+  };
+};

--- a/modules/lazy-load/index.test.ts
+++ b/modules/lazy-load/index.test.ts
@@ -2,6 +2,7 @@ import { newNoopLogger } from '@highfivve/ad-tag/lib/stubs/moliStubs';
 import { createMoliTag, Moli } from '@highfivve/ad-tag';
 import { moliPrebidTestConfig } from '@highfivve/ad-tag/lib/stubs/prebidjsStubs';
 import { dummySchainConfig } from '@highfivve/ad-tag/lib/stubs/schainStubs';
+import { MockIntersectionObserver } from '@highfivve/ad-tag/lib/stubs/intersectionObserverStubs';
 import { expect, use } from 'chai';
 import * as Sinon from 'sinon';
 import { createDom } from '@highfivve/ad-tag/lib/stubs/browserEnvSetup';
@@ -60,27 +61,6 @@ const createInfiniteAdSlotinConfig = (infiniteSlotClassSelector: string) => {
   return slot;
 };
 
-const MockIntersectionObserver = class MockIntersectionObserver implements IntersectionObserver {
-  readonly root: Element | Document | null = null;
-  readonly rootMargin: string = '0';
-  readonly thresholds: ReadonlyArray<number> = [];
-  constructor(private readonly callback, private readonly options) {}
-  observe() {
-    return;
-  }
-  unobserve() {
-    return;
-  }
-
-  disconnect(): void {
-    return;
-  }
-
-  takeRecords(): IntersectionObserverEntry[] {
-    return [];
-  }
-};
-
 use(sinonChai);
 
 describe('Lazy-load Module', () => {
@@ -93,9 +73,7 @@ describe('Lazy-load Module', () => {
   const errorLogSpy = sandbox.spy(noopLogger, 'error');
   let refreshAdSlotsSpy = sandbox.spy(jsDomWindow.moli, 'refreshAdSlot');
   let refreshBucketSpy = sandbox.spy(jsDomWindow.moli, 'refreshBucket');
-  let observer: IntersectionObserver = new MockIntersectionObserver(() => {
-    return;
-  }, {});
+  let observer: IntersectionObserver = new MockIntersectionObserver();
   let intersectionObserverConstructorStub = sandbox.stub(jsDomWindow, 'IntersectionObserver');
 
   const getIntersectionObserverCallback = (call: number): IntersectionObserverCallback => {
@@ -123,9 +101,7 @@ describe('Lazy-load Module', () => {
     refreshAdSlotsSpy = sandbox.spy(jsDomWindow.moli, 'refreshAdSlot');
     refreshBucketSpy = sandbox.spy(jsDomWindow.moli, 'refreshBucket');
 
-    observer = new MockIntersectionObserver(() => {
-      return;
-    }, {});
+    observer = new MockIntersectionObserver();
     intersectionObserverConstructorStub = sandbox.stub(jsDomWindow, 'IntersectionObserver');
     intersectionObserverConstructorStub.returns(observer);
   });

--- a/modules/lazy-load/index.ts
+++ b/modules/lazy-load/index.ts
@@ -52,6 +52,7 @@ import {
 } from '@highfivve/ad-tag';
 import MoliWindow = Moli.MoliWindow;
 import { selectInfiniteSlot } from './selectInfiniteSlot';
+import type { IntersectionObserverWindow } from '@highfivve/ad-tag/source/ts/types/dom';
 
 type LazyLoadModuleOptionsType = {
   /**
@@ -124,16 +125,7 @@ export type LazyLoadModuleConfig = {
  * To solve the Intersection Observer API typescript error
  * @see https://github.com/microsoft/TypeScript/issues/16255
  */
-export type LazyLoadWindow = Window &
-  MoliWindow & {
-    IntersectionObserver: {
-      prototype: IntersectionObserver;
-      new (
-        callback: IntersectionObserverCallback,
-        options?: IntersectionObserverInit
-      ): IntersectionObserver;
-    };
-  };
+export type LazyLoadWindow = Window & MoliWindow & IntersectionObserverWindow;
 
 /**
  * This module can be used to refresh ads based on slot visibility.


### PR DESCRIPTION
This enables ad reloads for special formats that are not captured by gpt.js viewability measurement and that have stable CSS selectors.