### PR TITLE
Add ad reload viewability overrides

### DIFF
--- a/ad-tag/source/ts/ads/modules/ad-reload/adVisibilityService.test.ts
+++ b/ad-tag/source/ts/ads/modules/ad-reload/adVisibilityService.test.ts
@@ -10,15 +10,25 @@ import { noopLogger } from 'ad-tag/stubs/moliStubs';
 import { createGoogletagStub, googleAdSlotStub } from 'ad-tag/stubs/googletagStubs';
 import { modules } from 'ad-tag/types/moliConfig';
 import RefreshIntervalOverrides = modules.adreload.RefreshIntervalOverrides;
+import type { IntersectionObserverWindow } from 'ad-tag/types/dom';
+import { MockIntersectionObserver } from 'ad-tag/stubs/dom';
 
 use(sinonChai);
 
 describe('AdVisibilityService', () => {
   const sandbox = Sinon.createSandbox();
   let dom = createDom();
-  let jsDomWindow: Window & googletag.IGoogleTagWindow = dom.window as any;
+  let jsDomWindow: Window & IntersectionObserverWindow & googletag.IGoogleTagWindow =
+    dom.window as any;
   (jsDomWindow as any).id = Math.random();
   const logger = noopLogger;
+
+  let observer: IntersectionObserver = new MockIntersectionObserver();
+  jsDomWindow.IntersectionObserver = MockIntersectionObserver;
+  let intersectionObserverConstructorStub = sandbox.stub(jsDomWindow, 'IntersectionObserver');
+
+  let observeSpy = sandbox.spy(observer, 'observe');
+  let unobserveSpy = sandbox.spy(observer, 'unobserve');
 
   after(() => {
     // bring everything back to normal after tests
@@ -27,6 +37,12 @@ describe('AdVisibilityService', () => {
 
   beforeEach(() => {
     jsDomWindow.googletag = createGoogletagStub();
+    jsDomWindow.IntersectionObserver = MockIntersectionObserver;
+    observer = new MockIntersectionObserver();
+    intersectionObserverConstructorStub = sandbox.stub(jsDomWindow, 'IntersectionObserver');
+    intersectionObserverConstructorStub.returns(observer);
+    observeSpy = sandbox.spy(observer, 'observe');
+    unobserveSpy = sandbox.spy(observer, 'unobserve');
     sandbox.useFakeTimers();
   });
 
@@ -42,7 +58,9 @@ describe('AdVisibilityService', () => {
   const tickInterval = 1000;
   const createAdVisibilityService = (
     disableVisibilityChecks: boolean,
-    overrides: RefreshIntervalOverrides = {}
+    overrides: RefreshIntervalOverrides = {},
+    viewabilityOverrides: modules.adreload.ViewabilityOverrides = {},
+    useIntersectionObserver = false
   ): AdVisibilityService => {
     const userActivityService = new UserActivityService(jsDomWindow, { level: 'strict' }, logger);
 
@@ -53,8 +71,9 @@ describe('AdVisibilityService', () => {
       userActivityService,
       adRefreshInterval,
       overrides,
-      false,
+      useIntersectionObserver,
       disableVisibilityChecks,
+      viewabilityOverrides,
       jsDomWindow,
       logger
     );
@@ -289,5 +308,224 @@ describe('AdVisibilityService', () => {
     expect(performanceNowStub).to.have.callCount(1 + 21 + 1);
 
     expect(refreshCallback).to.have.been.calledOnceWithExactly(slot);
+  });
+
+  describe('ViewabilityOverrides', () => {
+    const adSlotDomId = 'content-1';
+    const cssSelector = '.inScreen';
+    const viewabilityOverrides: modules.adreload.ViewabilityOverrides = {
+      [adSlotDomId]: { variant: 'css', cssSelector }
+    };
+
+    const createAndStubAdSlot = (adSlotDomId: string) => {
+      const slot = googleAdSlotStub('/123/content-1', adSlotDomId);
+      const slotElement = jsDomWindow.document.createElement('div');
+      return {
+        slot,
+        slotElement,
+        getElementByIdStub: sandbox
+          .stub(jsDomWindow.document, 'getElementById')
+          .returns(slotElement)
+      };
+    };
+
+    it('should not create an IntersectionObserver if useIntersectionObserver is false', () => {
+      createAdVisibilityService(false, {}, {}, false);
+      expect(intersectionObserverConstructorStub).to.not.have.been.called;
+    });
+
+    it('should create an IntersectionObserver if useIntersectionObserver is false, but overrides are provided', () => {
+      createAdVisibilityService(false, {}, viewabilityOverrides, false);
+      expect(intersectionObserverConstructorStub).to.have.been.calledOnce;
+    });
+
+    it('should create an IntersectionObserver if useIntersectionObserver is true', () => {
+      createAdVisibilityService(false, {}, {}, true);
+      expect(intersectionObserverConstructorStub).to.have.been.calledOnce;
+    });
+
+    describe('trackSlot with css variant', () => {
+      it('should track a slot with an IntersectionObserver if override is defined', () => {
+        const service = createAdVisibilityService(false, {}, viewabilityOverrides, false);
+
+        const { slot, getElementByIdStub } = createAndStubAdSlot(adSlotDomId);
+        const overrideElement = jsDomWindow.document.createElement('div');
+        const querySelectorStub = sandbox
+          .stub(jsDomWindow.document, 'querySelector')
+          .returns(overrideElement);
+
+        service.trackSlot(slot, sandbox.stub);
+
+        expect(getElementByIdStub).to.have.been.calledOnceWithExactly(slot.getSlotElementId());
+        expect(querySelectorStub).to.have.calledOnce;
+        expect(querySelectorStub).to.have.been.calledOnceWithExactly(cssSelector);
+        expect(observeSpy).to.have.been.calledOnceWithExactly(overrideElement);
+      });
+      it('should fallback to the slot element if the override element is not found and useIntersectionObserver is true', () => {
+        const service = createAdVisibilityService(false, {}, viewabilityOverrides, true);
+
+        const { slot, slotElement, getElementByIdStub } = createAndStubAdSlot(adSlotDomId);
+        const querySelectorStub = sandbox.stub(jsDomWindow.document, 'querySelector').returns(null);
+
+        service.trackSlot(slot, sandbox.stub);
+
+        expect(getElementByIdStub).to.have.been.calledOnceWithExactly(slot.getSlotElementId());
+        expect(querySelectorStub).to.have.calledOnce;
+        expect(querySelectorStub).to.have.been.calledOnceWithExactly(cssSelector);
+        expect(observeSpy).to.have.been.calledOnceWithExactly(slotElement);
+      });
+
+      it('should not call observe if the override element is not found and userIntersectionObserver is false', () => {
+        const service = createAdVisibilityService(false, {}, viewabilityOverrides, false);
+        const { slot, getElementByIdStub } = createAndStubAdSlot(adSlotDomId);
+        const querySelectorStub = sandbox.stub(jsDomWindow.document, 'querySelector').returns(null);
+
+        service.trackSlot(slot, sandbox.stub);
+
+        expect(getElementByIdStub).to.have.been.calledOnceWithExactly(slot.getSlotElementId());
+        expect(querySelectorStub).to.have.calledOnce;
+        expect(querySelectorStub).to.have.been.calledOnceWithExactly(cssSelector);
+        expect(observeSpy).to.not.have.been.called;
+      });
+
+      describe('removeSlotTracking', () => {
+        it('should unobserve the override element if it exists', () => {
+          const service = createAdVisibilityService(false, {}, viewabilityOverrides, false);
+          const { slot } = createAndStubAdSlot(adSlotDomId);
+          const overrideElement = jsDomWindow.document.createElement('div');
+          sandbox.stub(jsDomWindow.document, 'querySelector').returns(overrideElement);
+
+          service.trackSlot(slot, sandbox.stub);
+          service.removeSlotTracking(slot);
+
+          expect(observeSpy).to.have.been.calledOnceWithExactly(overrideElement);
+          expect(unobserveSpy).to.have.been.calledOnce;
+          expect(unobserveSpy).to.have.been.calledOnceWithExactly(overrideElement);
+        });
+      });
+    });
+
+    describe('trackSlot with disabled variant', () => {
+      const adSlotDomId = 'content-1';
+      const viewabilityOverrides: modules.adreload.ViewabilityOverrides = {
+        [adSlotDomId]: { variant: 'disabled', disableAllAdVisibilityChecks: true }
+      };
+
+      it('should not create an IntersectionObserver if useIntersectionObserver is false', () => {
+        createAdVisibilityService(false, {}, viewabilityOverrides, false);
+        expect(intersectionObserverConstructorStub).to.not.have.been.called;
+      });
+
+      it('should create an IntersectionObserver if useIntersectionObserver is true', () => {
+        createAdVisibilityService(false, {}, viewabilityOverrides, true);
+        expect(intersectionObserverConstructorStub).to.have.been.calledOnce;
+      });
+
+      it('should not call observe if the variant is disabled', () => {
+        const service = createAdVisibilityService(false, {}, viewabilityOverrides, false);
+        const { slot } = createAndStubAdSlot(adSlotDomId);
+
+        service.trackSlot(slot, sandbox.stub);
+
+        expect(observeSpy).to.not.have.been.called;
+      });
+
+      it('disableVisibilityChecks: should call the refreshCallback even if slot is out of viewport and NO googletag visibility event was received', () => {
+        const { slot } = createAndStubAdSlot(adSlotDomId);
+
+        // performance.now needs to be stubbed "by hand":
+        // https://www.bountysource.com/issues/50501976-fake-timers-in-sinon-doesn-t-work-with-performance-now
+        const performanceNowStub = sandbox.stub(jsDomWindow.performance, 'now');
+
+        Array.from({ length: 30 }).forEach((_, index) => {
+          performanceNowStub.onCall(index).returns((index + 1) * 1000);
+        });
+
+        const service = createAdVisibilityService(false, {}, viewabilityOverrides, false);
+
+        const refreshCallback = sandbox.stub();
+        service.trackSlot(slot, refreshCallback);
+
+        sandbox.clock.tick(adRefreshInterval + tickInterval);
+
+        // initial call for ad slot visibility + 21 calls accounting for 1..20s + final call when refreshing the slot
+        // note that no slot visibility event had to be fired.
+        expect(performanceNowStub).to.have.callCount(1 + 21 + 1);
+
+        expect(refreshCallback).to.have.been.calledOnceWithExactly(slot);
+      });
+
+      it('disableVisibilityChecks: should call the refreshCallback even if slot is out of viewport and NO googletag visibility event was received for specified advertiserId', () => {
+        const { slot } = createAndStubAdSlot(adSlotDomId);
+
+        // performance.now needs to be stubbed "by hand":
+        // https://www.bountysource.com/issues/50501976-fake-timers-in-sinon-doesn-t-work-with-performance-now
+        const performanceNowStub = sandbox.stub(jsDomWindow.performance, 'now');
+
+        Array.from({ length: 30 }).forEach((_, index) => {
+          performanceNowStub.onCall(index).returns((index + 1) * 1000);
+        });
+
+        const service = createAdVisibilityService(
+          false,
+          {},
+          {
+            [adSlotDomId]: {
+              variant: 'disabled',
+              disableAllAdVisibilityChecks: false,
+              disabledAdVisibilityCheckAdvertiserIds: [55555]
+            }
+          },
+          false
+        );
+
+        const refreshCallback = sandbox.stub();
+        service.trackSlot(slot, refreshCallback, 55555);
+
+        sandbox.clock.tick(adRefreshInterval + tickInterval);
+
+        // initial call for ad slot visibility + 21 calls accounting for 1..20s + final call when refreshing the slot
+        // note that no slot visibility event had to be fired.
+        expect(performanceNowStub).to.have.callCount(1 + 21 + 1);
+
+        expect(refreshCallback).to.have.been.calledOnceWithExactly(slot);
+      });
+
+      it('disableVisibilityChecks: should not call the refreshCallback even if slot is out of viewport and NO googletag visibility event was received for specified advertiserId', () => {
+        const { slot } = createAndStubAdSlot(adSlotDomId);
+
+        // performance.now needs to be stubbed "by hand":
+        // https://www.bountysource.com/issues/50501976-fake-timers-in-sinon-doesn-t-work-with-performance-now
+        const performanceNowStub = sandbox.stub(jsDomWindow.performance, 'now');
+
+        Array.from({ length: 30 }).forEach((_, index) => {
+          performanceNowStub.onCall(index).returns((index + 1) * 1000);
+        });
+
+        const service = createAdVisibilityService(
+          false,
+          {},
+          {
+            [adSlotDomId]: {
+              variant: 'disabled',
+              disableAllAdVisibilityChecks: false,
+              disabledAdVisibilityCheckAdvertiserIds: [55555]
+            }
+          },
+          false
+        );
+
+        const refreshCallback = sandbox.stub();
+        service.trackSlot(slot, refreshCallback, 44444);
+
+        sandbox.clock.tick(adRefreshInterval + tickInterval);
+
+        // initial call for ad slot visibility + 21 calls accounting for 1..20s + final call when refreshing the slot
+        // note that no slot visibility event had to be fired.
+        expect(performanceNowStub).to.have.not.been.called;
+
+        expect(refreshCallback).to.have.not.been.called;
+      });
+    });
   });
 });

--- a/ad-tag/source/ts/ads/modules/ad-reload/adVisibilityService.ts
+++ b/ad-tag/source/ts/ads/modules/ad-reload/adVisibilityService.ts
@@ -1,7 +1,8 @@
 import { UserActivityService } from './userActivityService';
-import { googletag } from 'ad-tag/types/googletag';
-import { modules } from 'ad-tag/types/moliConfig';
-import { MoliRuntime } from 'ad-tag/types/moliRuntime';
+import type { googletag } from 'ad-tag/types/googletag';
+import type { modules } from 'ad-tag/types/moliConfig';
+import type { MoliRuntime } from 'ad-tag/types/moliRuntime';
+import type { IntersectionObserverWindow } from 'ad-tag/types/dom';
 
 /**
  * Tracks the visibility of ad slots.
@@ -29,7 +30,7 @@ export class AdVisibilityService {
   /**
    * Ratio that an ad has to be in the visible viewport of the browser to be considered seen. 0.5 = 50%.
    */
-  private readonly minimalAdVisibilityRatio;
+  private readonly minimalAdVisibilityRatio: number;
 
   private visibilityRecords: Map<string, VisibilityRecord>;
   private readonly intersectionObserver?: IntersectionObserver;
@@ -45,15 +46,23 @@ export class AdVisibilityService {
     private readonly refreshIntervalOverrides: modules.adreload.RefreshIntervalOverrides,
     readonly useIntersectionObserver: boolean,
     private readonly disableAdVisibilityChecks: boolean,
-    private readonly window: Window & googletag.IGoogleTagWindow,
+    private readonly viewabilityOverrides: modules.adreload.ViewabilityOverrides,
+    private readonly window: Window & IntersectionObserverWindow & googletag.IGoogleTagWindow,
     private readonly logger?: MoliRuntime.MoliLogger
   ) {
     this.minimalAdVisibilityRatio = disableAdVisibilityChecks ? 0 : 0.5;
 
     this.visibilityRecords = new Map<string, VisibilityRecord>();
 
-    if (useIntersectionObserver && 'IntersectionObserver' in this.window) {
-      this.intersectionObserver = new IntersectionObserver(
+    // instantiate IntersectionObserver if it is enabled or if there are custom overrides that
+    // require an observer to be available
+    const requiredIntersectionObserver =
+      (useIntersectionObserver ||
+        Object.values(viewabilityOverrides).some(entry => entry?.variant === 'css')) &&
+      'IntersectionObserver' in this.window;
+
+    if (requiredIntersectionObserver) {
+      this.intersectionObserver = new this.window.IntersectionObserver(
         entries => this.handleObservedAdVisibilityChanged(entries),
         { threshold: this.minimalAdVisibilityRatio }
       );
@@ -84,10 +93,15 @@ export class AdVisibilityService {
    *
    * @param slot              a refreshable ad slot with "visibility" trigger
    * @param refreshCallback   callback fired when the configured duration is up
+   * @param advertiserId      optional advertiser id to check against disallowed advertisers
    */
-  trackSlot(slot: googletag.IAdSlot, refreshCallback: (slot: googletag.IAdSlot) => void): void {
+  trackSlot(
+    slot: googletag.IAdSlot,
+    refreshCallback: (slot: googletag.IAdSlot) => void,
+    advertiserId?: number
+  ): void {
     const slotDomId = slot.getSlotElementId();
-    const domElement = this.window.document.getElementById(slotDomId);
+    const domElement = this.observedDomElementForSlot(slot);
 
     if (domElement) {
       this.logger?.debug('AdVisibilityService', `tracking slot ${slot.getSlotElementId()}`, slot);
@@ -96,17 +110,33 @@ export class AdVisibilityService {
         this.removeSlotTracking(slot);
       }
 
+      const override = domElement.viewabilityOverride;
       this.visibilityRecords.set(slot.getSlotElementId(), {
         slot: slot,
-        latestStartVisible: this.disableAdVisibilityChecks
-          ? this.window.performance.now()
-          : undefined,
+        latestStartVisible:
+          this.disableAdVisibilityChecks ||
+          (override?.variant === 'disabled' &&
+            // either all checks are disabled or the current advertiser is not in the list of disabled advertisers
+            (override.disableAllAdVisibilityChecks ||
+              !(
+                override.disabledAdVisibilityCheckAdvertiserIds &&
+                override.disabledAdVisibilityCheckAdvertiserIds.length > 0 &&
+                advertiserId
+              ) ||
+              override.disabledAdVisibilityCheckAdvertiserIds.includes(advertiserId)))
+            ? this.window.performance.now()
+            : undefined,
         durationVisibleSum: 0,
         refreshCallback: refreshCallback
       });
 
-      if (this.intersectionObserver) {
-        this.intersectionObserver.observe(domElement);
+      // use intersection observer if required due to viewability overrides or because it is globally
+      // enabled ( usually for none gpt.js environments like test or prebid-only setups )
+      if (
+        this.intersectionObserver &&
+        (domElement.targetOverride || this.useIntersectionObserver)
+      ) {
+        this.intersectionObserver.observe(domElement.target);
       }
     }
   }
@@ -119,6 +149,11 @@ export class AdVisibilityService {
     );
 
     this.visibilityRecords.delete(slot.getSlotElementId());
+
+    const observedSlot = this.observedDomElementForSlot(slot);
+    if (this.intersectionObserver && observedSlot) {
+      this.intersectionObserver.unobserve(observedSlot.target);
+    }
   };
 
   private setUpdateTimer(state: boolean): void {
@@ -260,6 +295,30 @@ export class AdVisibilityService {
   private visibilityRecordForGoogletagEvent = (
     event: googletag.events.ISlotVisibilityChangedEvent
   ): VisibilityRecord | undefined => this.visibilityRecords.get(event.slot.getSlotElementId());
+
+  /**
+   * use the override element if it exists, otherwise use the ad slot element
+   * this is necessary for ad formats that do not exist inside the regular ad slot element
+   * @param slot
+   */
+  private observedDomElementForSlot(slot: googletag.IAdSlot): {
+    target: HTMLElement;
+    targetOverride: boolean;
+    viewabilityOverride?: modules.adreload.ViewabilityOverrideEntry;
+  } | null {
+    const slotDomId = slot.getSlotElementId();
+    const viewabilityOverride = this.viewabilityOverrides[slotDomId];
+    const adSlotElement = this.window.document.getElementById(slotDomId);
+    const overrideElement =
+      viewabilityOverride && viewabilityOverride.variant === 'css'
+        ? this.window.document.querySelector<HTMLElement>(viewabilityOverride.cssSelector)
+        : null;
+    return overrideElement
+      ? { target: overrideElement, targetOverride: true, viewabilityOverride }
+      : adSlotElement
+        ? { target: adSlotElement, targetOverride: false, viewabilityOverride }
+        : null;
+  }
 }
 
 /**

--- a/ad-tag/source/ts/ads/modules/ad-reload/index.ts
+++ b/ad-tag/source/ts/ads/modules/ad-reload/index.ts
@@ -60,6 +60,7 @@ import {
 } from '../../adPipeline';
 import { AdSlot, googleAdManager, modules } from 'ad-tag/types/moliConfig';
 import { MoliRuntime } from 'ad-tag/types/moliRuntime';
+import { IntersectionObserverWindow } from 'ad-tag/types/dom';
 /**
  * This module can be used to refresh ads based on user activity after a certain amount of time that the ad was visible.
  */
@@ -158,7 +159,11 @@ export class AdReload implements IModule {
 
     context.logger.debug('AdReload', 'initialize moli ad reload module');
 
-    this.setupAdVisibilityService(config, context.window, context.logger);
+    this.setupAdVisibilityService(
+      config,
+      context.window as unknown as Window & IntersectionObserverWindow & googletag.IGoogleTagWindow,
+      context.logger
+    );
     this.setupSlotRenderListener(
       config,
       slotsToMonitor,
@@ -172,15 +177,16 @@ export class AdReload implements IModule {
 
   private setupAdVisibilityService = (
     config: modules.adreload.AdReloadModuleConfig,
-    window: Window & googletag.IGoogleTagWindow,
+    window: Window & IntersectionObserverWindow & googletag.IGoogleTagWindow,
     logger: MoliRuntime.MoliLogger
   ): void => {
     this.adVisibilityService = new AdVisibilityService(
       new UserActivityService(window, config.userActivityLevelControl, logger),
       this.refreshIntervalMs,
-      config.refreshIntervalMsOverrides || {},
+      config.refreshIntervalMsOverrides ?? {},
       false,
       !!config.disableAdVisibilityChecks,
+      config.viewabilityOverrides ?? {},
       window,
       logger
     );

--- a/ad-tag/source/ts/stubs/dom.ts
+++ b/ad-tag/source/ts/stubs/dom.ts
@@ -1,0 +1,27 @@
+const MockIntersectionObserver = class MockIntersectionObserver implements IntersectionObserver {
+  readonly root: Element | Document | null = null;
+  readonly rootMargin: string = '0';
+  readonly thresholds: ReadonlyArray<number> = [];
+  constructor(
+    callback?: IntersectionObserverCallback | undefined,
+    options?: IntersectionObserverInit | undefined
+  ) {
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+  }
+  observe() {
+    return;
+  }
+  unobserve() {
+    return;
+  }
+
+  disconnect(): void {
+    return;
+  }
+
+  takeRecords(): IntersectionObserverEntry[] {
+    return [];
+  }
+};
+
+export { MockIntersectionObserver };

--- a/ad-tag/source/ts/types/dom.ts
+++ b/ad-tag/source/ts/types/dom.ts
@@ -1,0 +1,13 @@
+/**
+ * To solve the Intersection Observer API typescript error
+ * @see https://github.com/microsoft/TypeScript/issues/16255
+ */
+export type IntersectionObserverWindow = {
+  IntersectionObserver: {
+    prototype: IntersectionObserver;
+    new (
+      callback: IntersectionObserverCallback,
+      options?: IntersectionObserverInit
+    ): IntersectionObserver;
+  };
+};

--- a/ad-tag/source/ts/types/moliConfig.ts
+++ b/ad-tag/source/ts/types/moliConfig.ts
@@ -902,6 +902,64 @@ export namespace modules {
       [slotDomId: string]: number;
     };
 
+    export type ViewabilityOverrideEntryCss = {
+      variant: 'css';
+      /** Used to select a single element to monitor for viewability */
+      cssSelector: string;
+    };
+
+    export type ViewabilityOverrideEntryDisabled = {
+      /**
+       * Enable reloading ads that are not in viewport. It is not advised to use this option.
+       * Impressions are usually only counted on ads that have been 50% visible, and it's generally not
+       * very user-centric to load stuff that is out of viewport.
+       */
+      variant: 'disabled';
+
+      /**
+       * Enable reloading ads that are not in viewport without any restrictions.
+       *
+       * It is not advised to use this option. Impressions are usually only counted on ads that
+       * have been 50% visible, and it's generally not very user-centric to load stuff that is out
+       * of viewport.
+       *
+       * Set this to false and provide additional configuration options to restrict the unconditional
+       * ad reload to certain advertisers.
+       */
+      disableAllAdVisibilityChecks: boolean;
+
+      /**
+       *  An optional list of advertisers that are allowed to be reloaded, but no additional ad visibility check is performed.
+       *  This is necessary for special formats that may take a bit of time to render and the DOM elements are not yet ready,
+       *  when the IntersectionObserver is about to be configured.
+       */
+      disabledAdVisibilityCheckAdvertiserIds?: number[];
+    };
+
+    /**
+     * A set of different configuration options for a viewability override setting.
+     * Each entry is per position and can be used to override the default viewability behavior.
+     */
+    export type ViewabilityOverrideEntry =
+      | ViewabilityOverrideEntryCss
+      | ViewabilityOverrideEntryDisabled;
+
+    /**
+     * Viewability is measured by gpt visibility events or a separate IntersectionObserver.
+     *
+     * This configuration object allows to provide a CSS selector to check for visibility.
+     * If set and available in the DOM it will be used to check for visibility with an IntersectionObserver.
+     * Otherwise, the configured default behavior will be used.
+     *
+     * A record in this overrides object is a mapping of a slot's DOM id to the override configuration.
+     */
+    export type ViewabilityOverrides = {
+      /**
+       * Ad Slot DOM ID to viewability configuration
+       */
+      [slotDomId: string]: ViewabilityOverrideEntry | undefined;
+    };
+
     export type UserActivityParameters = {
       /**
        * The duration in milliseconds the page is considered to be "actively used" after the last user action. Changes to page visibility
@@ -985,6 +1043,19 @@ export namespace modules {
        * very user-centric to load stuff that is out of viewport.
        */
       disableAdVisibilityChecks?: boolean;
+
+      /**
+       * Overrides the default viewability measurement with a custom target DOM element.
+       *
+       * This can be used to measure viewability of an ad slot that is not using the default ad slot
+       * div container, but creates a separate container on the page. This is the case for certain
+       * special ad formats like seedtag's or GumGum's inScreen, YOCs mystery scroller and similar mobile
+       * sticky formats.
+       *
+       * It can also be used to measure viewability for ad skin formats to apply ad reload accordingly.
+       *
+       */
+      viewabilityOverrides?: ViewabilityOverrides;
     }
   }
 

--- a/schema.json
+++ b/schema.json
@@ -1469,6 +1469,10 @@
         "userActivityLevelControl": {
           "$ref": "#/definitions/modules.adreload.UserActivityLevelControl",
           "description": "Configure what defines a user as active / inactive."
+        },
+        "viewabilityOverrides": {
+          "$ref": "#/definitions/modules.adreload.ViewabilityOverrides",
+          "description": "Overrides the default viewability measurement with a custom target DOM element.\n\nThis can be used to measure viewability of an ad slot that is not using the default ad slot div container, but creates a separate container on the page. This is the case for certain special ad formats like seedtag's or GumGum's inScreen, YOCs mystery scroller and similar mobile sticky formats.\n\nIt can also be used to measure viewability for ad skin formats to apply ad reload accordingly."
         }
       },
       "required": [
@@ -1554,6 +1558,76 @@
         }
       ],
       "description": "Used to configure the strictness of user activity checks."
+    },
+    "modules.adreload.ViewabilityOverrideEntry": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/modules.adreload.ViewabilityOverrideEntryCss"
+        },
+        {
+          "$ref": "#/definitions/modules.adreload.ViewabilityOverrideEntryDisabled"
+        }
+      ],
+      "description": "A set of different configuration options for a viewability override setting. Each entry is per position and can be used to override the default viewability behavior."
+    },
+    "modules.adreload.ViewabilityOverrideEntryCss": {
+      "additionalProperties": false,
+      "properties": {
+        "cssSelector": {
+          "description": "Used to select a single element to monitor for viewability",
+          "type": "string"
+        },
+        "variant": {
+          "const": "css",
+          "type": "string"
+        }
+      },
+      "required": [
+        "variant",
+        "cssSelector"
+      ],
+      "type": "object"
+    },
+    "modules.adreload.ViewabilityOverrideEntryDisabled": {
+      "additionalProperties": false,
+      "properties": {
+        "disableAllAdVisibilityChecks": {
+          "description": "Enable reloading ads that are not in viewport without any restrictions.\n\nIt is not advised to use this option. Impressions are usually only counted on ads that have been 50% visible, and it's generally not very user-centric to load stuff that is out of viewport.\n\nSet this to false and provide additional configuration options to restrict the unconditional ad reload to certain advertisers.",
+          "type": "boolean"
+        },
+        "disabledAdVisibilityCheckAdvertiserIds": {
+          "description": "An optional list of advertisers that are allowed to be reloaded, but no additional ad visibility check is performed. This is necessary for special formats that may take a bit of time to render and the DOM elements are not yet ready, when the IntersectionObserver is about to be configured.",
+          "items": {
+            "type": "number"
+          },
+          "type": "array"
+        },
+        "variant": {
+          "const": "disabled",
+          "description": "Enable reloading ads that are not in viewport. It is not advised to use this option. Impressions are usually only counted on ads that have been 50% visible, and it's generally not very user-centric to load stuff that is out of viewport.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "variant",
+        "disableAllAdVisibilityChecks"
+      ],
+      "type": "object"
+    },
+    "modules.adreload.ViewabilityOverrides": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "$ref": "#/definitions/modules.adreload.ViewabilityOverrideEntry"
+          },
+          {
+            "not": {}
+          }
+        ],
+        "description": "Ad Slot DOM ID to viewability configuration"
+      },
+      "description": "Viewability is measured by gpt visibility events or a separate IntersectionObserver.\n\nThis configuration object allows to provide a CSS selector to check for visibility. If set and available in the DOM it will be used to check for visibility with an IntersectionObserver. Otherwise, the configured default behavior will be used.\n\nA record in this overrides object is a mapping of a slot's DOM id to the override configuration.",
+      "type": "object"
     },
     "modules.blocklist.Blocklist": {
       "additionalProperties": false,


### PR DESCRIPTION
Ports #368 and #366

Adds the option to override how viewability is measured during ad reloads. This is handy for special formats that don't adhere to regular viewability measurement through `gpt.js`, because they create new ad containers on the page.

Use with caution!