### PR TITLE
Do not track slots without a DOM ID

### DIFF
--- a/ad-tag/source/ts/ads/modules/ad-reload/index.ts
+++ b/ad-tag/source/ts/ads/modules/ad-reload/index.ts
@@ -61,6 +61,7 @@ import {
 import { AdSlot, googleAdManager, modules } from 'ad-tag/types/moliConfig';
 import { MoliRuntime } from 'ad-tag/types/moliRuntime';
 import { IntersectionObserverWindow } from 'ad-tag/types/dom';
+import { isNotNull } from 'ad-tag/util/arrayUtils';
 /**
  * This module can be used to refresh ads based on user activity after a certain amount of time that the ad was visible.
  */
@@ -116,7 +117,8 @@ export class AdReload implements IModule {
             const slotsToMonitor = context.config.slots
               // filter out slots excluded by dom id
               .filter(slot => config.excludeAdSlotDomIds.indexOf(slot.domId) === -1)
-              .map(slot => slot.domId);
+              .map(slot => slot.domId)
+              .filter(isNotNull);
 
             const reloadAdSlotCallback: (slot: googletag.IAdSlot) => void = this.reloadAdSlot(
               config,


### PR DESCRIPTION
This might bite us in the future for out-of-page ad slots that we want to reload. However we need to use ad unit paths in this case any way.