### PR TITLE
Fallback to top level private domain on first party data

### DIFF
--- a/ad-tag/source/ts/ads/modules/prebid-first-party-data/index.test.ts
+++ b/ad-tag/source/ts/ads/modules/prebid-first-party-data/index.test.ts
@@ -28,7 +28,7 @@ use(chaiAsPromised);
 
 describe('Prebid First Party Data Module', () => {
   const sandbox = Sinon.createSandbox();
-  let { jsDomWindow } = createDomAndWindow();
+  let { dom, jsDomWindow } = createDomAndWindow();
 
   const assetLoaderService = createAssetLoaderService(jsDomWindow);
   const adPipelineContext = (config: MoliConfig): AdPipelineContext => {
@@ -55,7 +55,9 @@ describe('Prebid First Party Data Module', () => {
   });
 
   afterEach(() => {
-    jsDomWindow = createDomAndWindow().jsDomWindow;
+    const result = createDomAndWindow();
+    jsDomWindow = result.jsDomWindow;
+    dom = result.dom;
     sandbox.reset();
     sandbox.restore();
   });
@@ -64,7 +66,7 @@ describe('Prebid First Party Data Module', () => {
     staticPrebidFirstPartyData: prebidjs.firstpartydata.PrebidFirstPartyData,
     gptTargetingMappings?: modules.prebid_first_party_data.GptTargetingMapping,
     iabDataProviderName?: string
-  ): PrebidFirstPartyDataModule => {
+  ) => {
     const module = new PrebidFirstPartyDataModule();
 
     module.configure({
@@ -75,7 +77,7 @@ describe('Prebid First Party Data Module', () => {
         iabDataProviderName
       }
     });
-    return module;
+    return { module, configureStep: module.configureSteps()[0] };
   };
 
   const configWithTargeting = (targeting: googleAdManager.Targeting): MoliConfig => ({
@@ -90,7 +92,7 @@ describe('Prebid First Party Data Module', () => {
 
   describe('configure', () => {
     it('should add a configure step', () => {
-      const module = createFpdModule({}, { cat: 'openrtb2_page_cat' });
+      const { module } = createFpdModule({}, { cat: 'openrtb2_page_cat' });
 
       const configureSteps = module.configureSteps();
 
@@ -107,7 +109,7 @@ describe('Prebid First Party Data Module', () => {
     });
 
     it('should call pbjs.setConfig() with the configured first party data', async () => {
-      const module = createFpdModule(
+      const { configureStep } = createFpdModule(
         { user: { gender: 'O', yob: 1337, keywords: 'some,nice,guy' } },
         { cat: 'openrtb2_cat', pageCat: 'openrtb2_page_cat', iabV3: 'iab_v3', iabV2: 'iab_v2' },
         'test.com'
@@ -122,7 +124,7 @@ describe('Prebid First Party Data Module', () => {
         }
       });
 
-      await module.configureSteps()[0](adPipelineContext(moliConfig), []);
+      await configureStep(adPipelineContext(moliConfig), []);
 
       const expected: PrebidFirstPartyData = {
         site: {
@@ -133,40 +135,18 @@ describe('Prebid First Party Data Module', () => {
             data: [
               {
                 name: 'test.com',
-                ext: {
-                  segtax: 6
-                },
-                segment: [
-                  {
-                    id: '111'
-                  },
-                  {
-                    id: '222'
-                  }
-                ]
+                ext: { segtax: 6 },
+                segment: [{ id: '111' }, { id: '222' }]
               },
               {
                 name: 'test.com',
-                ext: {
-                  segtax: 7
-                },
-                segment: [
-                  {
-                    id: '123'
-                  },
-                  {
-                    id: '456'
-                  }
-                ]
+                ext: { segtax: 7 },
+                segment: [{ id: '123' }, { id: '456' }]
               }
             ]
           }
         },
-        user: {
-          gender: 'O',
-          yob: 1337,
-          keywords: 'some,nice,guy'
-        }
+        user: { gender: 'O', yob: 1337, keywords: 'some,nice,guy' }
       };
       expect(setConfigSpy).to.have.been.calledOnce;
       expect(setConfigSpy).to.have.been.calledOnceWithExactly({
@@ -174,10 +154,48 @@ describe('Prebid First Party Data Module', () => {
       });
     });
 
+    describe('iab provider name', () => {
+      const iabProviderMoliConfig: MoliConfig = configWithTargeting({
+        keyValues: { iab_v3: ['123', '456'] }
+      });
+
+      it('should use the configured iabDataProviderName', async () => {
+        const { configureStep } = createFpdModule(
+          {},
+          { cat: 'openrtb2_cat', iabV3: 'iab_v3' },
+          'test.com'
+        );
+
+        await configureStep(adPipelineContext(iabProviderMoliConfig), []);
+
+        expect(setConfigSpy).to.have.been.calledOnce;
+        const site = setConfigSpy.firstCall.firstArg.ortb2.site as OpenRtb2Site;
+        expect(site.content?.data?.map(value => value.name)).to.deep.equals(['test.com']);
+      });
+
+      it('should use the tld as iabDataProviderName if none is configured', async () => {
+        const { configureStep } = createFpdModule(
+          {},
+          { cat: 'openrtb2_cat', iabV3: 'iab_v3', iabV2: 'iab_v2' }
+        );
+        dom.reconfigure({
+          url: 'https://www.test.com'
+        });
+
+        await configureStep(adPipelineContext(iabProviderMoliConfig), []);
+
+        expect(setConfigSpy).to.have.been.calledOnce;
+        const site = setConfigSpy.firstCall.firstArg.ortb2.site as OpenRtb2Site;
+        expect(site.content?.data?.map(value => value.name)).to.deep.equals([
+          'test.com',
+          'test.com'
+        ]);
+      });
+    });
+
     describe('iab category fallbacks', () => {
       it('should not set any iab categories if none is configured', async () => {
-        const module = createFpdModule({});
-        const configureStep = module.configureSteps()[0];
+        const { configureStep } = createFpdModule({});
 
         const moliConfig: MoliConfig = configWithTargeting({
           keyValues: {
@@ -193,7 +211,7 @@ describe('Prebid First Party Data Module', () => {
       });
 
       it('should use cat as fallback for pagecat', async () => {
-        const module = createFpdModule(
+        const { configureStep } = createFpdModule(
           {},
           { cat: 'openrtb2_cat', sectionCat: 'openrtb2_section_cat' }
         );
@@ -205,7 +223,7 @@ describe('Prebid First Party Data Module', () => {
           }
         });
 
-        await module.configureSteps()[0](adPipelineContext(moliConfig), []);
+        await configureStep(adPipelineContext(moliConfig), []);
 
         expect(setConfigSpy).to.have.been.calledOnce;
         const site = setConfigSpy.firstCall.firstArg.ortb2.site as OpenRtb2Site;
@@ -215,7 +233,10 @@ describe('Prebid First Party Data Module', () => {
       });
 
       it('should use cat as fallback for sectioncat', async () => {
-        const module = createFpdModule({}, { cat: 'openrtb2_cat', pageCat: 'openrtb2_page_cat' });
+        const { configureStep } = createFpdModule(
+          {},
+          { cat: 'openrtb2_cat', pageCat: 'openrtb2_page_cat' }
+        );
 
         const moliConfig: MoliConfig = configWithTargeting({
           keyValues: {
@@ -224,7 +245,7 @@ describe('Prebid First Party Data Module', () => {
           }
         });
 
-        await module.configureSteps()[0](adPipelineContext(moliConfig), []);
+        await configureStep(adPipelineContext(moliConfig), []);
 
         expect(setConfigSpy).to.have.been.calledOnce;
         const site = setConfigSpy.firstCall.firstArg.ortb2.site as OpenRtb2Site;
@@ -242,7 +263,7 @@ describe('Prebid First Party Data Module', () => {
       });
 
       it('should filter all data rows from configured iabDataProviderName to avoid duplicates', async () => {
-        const module = createFpdModule({}, { iabV3: 'iab_v3' }, 'test.com');
+        const { configureStep } = createFpdModule({}, { iabV3: 'iab_v3' }, 'test.com');
 
         const moliConfig: MoliConfig = configWithTargeting({
           keyValues: {
@@ -257,17 +278,8 @@ describe('Prebid First Party Data Module', () => {
                 data: [
                   {
                     name: 'test2.com',
-                    ext: {
-                      segtax: 7
-                    },
-                    segment: [
-                      {
-                        id: 'xxx'
-                      },
-                      {
-                        id: 'yyy'
-                      }
-                    ]
+                    ext: { segtax: 7 },
+                    segment: [{ id: 'xxx' }, { id: 'yyy' }]
                   }
                 ]
               }
@@ -275,7 +287,7 @@ describe('Prebid First Party Data Module', () => {
           }
         });
 
-        await module.configureSteps()[0](adPipelineContext(moliConfig), []);
+        await configureStep(adPipelineContext(moliConfig), []);
 
         const expected: PrebidFirstPartyData = {
           site: {
@@ -286,32 +298,10 @@ describe('Prebid First Party Data Module', () => {
               data: [
                 {
                   name: 'test2.com',
-                  ext: {
-                    segtax: 7
-                  },
-                  segment: [
-                    {
-                      id: 'xxx'
-                    },
-                    {
-                      id: 'yyy'
-                    }
-                  ]
+                  ext: { segtax: 7 },
+                  segment: [{ id: 'xxx' }, { id: 'yyy' }]
                 },
-                {
-                  name: 'test.com',
-                  ext: {
-                    segtax: 7
-                  },
-                  segment: [
-                    {
-                      id: '123'
-                    },
-                    {
-                      id: '456'
-                    }
-                  ]
-                }
+                { name: 'test.com', ext: { segtax: 7 }, segment: [{ id: '123' }, { id: '456' }] }
               ]
             }
           }
@@ -332,7 +322,7 @@ describe('Prebid First Party Data Module', () => {
       });
 
       it('should prefer key value data over static data', async () => {
-        const module = createFpdModule(
+        const { configureStep } = createFpdModule(
           { user: { keywords: 'static' }, site: { cat: ['IAB-9'] } },
           { cat: 'openrtb2_cat' }
         );
@@ -345,7 +335,7 @@ describe('Prebid First Party Data Module', () => {
             site: { cat: ['IAB-1'] }
           }
         });
-        await module.configureSteps()[0](adPipelineContext(moliConfig), []);
+        await configureStep(adPipelineContext(moliConfig), []);
         expect(setConfigSpy).to.have.been.calledOnce;
         const site = setConfigSpy.firstCall.firstArg.ortb2.site as OpenRtb2Site;
         const user = setConfigSpy.firstCall.firstArg.ortb2.user as OpenRtb2User;
@@ -354,7 +344,7 @@ describe('Prebid First Party Data Module', () => {
       });
 
       it('should prefer existing fpd data over key value data', async () => {
-        const module = createFpdModule({}, { cat: 'openrtb2_cat' });
+        const { configureStep } = createFpdModule({}, { cat: 'openrtb2_cat' });
 
         const moliConfig: MoliConfig = configWithTargeting({
           keyValues: {
@@ -369,7 +359,7 @@ describe('Prebid First Party Data Module', () => {
           }
         });
 
-        await module.configureSteps()[0](adPipelineContext(moliConfig), []);
+        await configureStep(adPipelineContext(moliConfig), []);
         expect(setConfigSpy).to.have.been.calledOnce;
         const site = setConfigSpy.firstCall.firstArg.ortb2.site as OpenRtb2Site;
         expect(site.cat).to.deep.equals(['IAB-1', 'IAB-9']);
@@ -378,7 +368,7 @@ describe('Prebid First Party Data Module', () => {
       });
 
       it('should keep data in site.ext.data', async () => {
-        const module = createFpdModule({}, { cat: 'openrtb2_cat' });
+        const { configureStep } = createFpdModule({}, { cat: 'openrtb2_cat' });
 
         const moliConfig: MoliConfig = configWithTargeting({
           keyValues: {
@@ -392,7 +382,7 @@ describe('Prebid First Party Data Module', () => {
           }
         });
 
-        await module.configureSteps()[0](adPipelineContext(moliConfig), []);
+        await configureStep(adPipelineContext(moliConfig), []);
         expect(setConfigSpy).to.have.been.calledOnce;
         const site = setConfigSpy.firstCall.firstArg.ortb2.site as OpenRtb2Site;
         expect(site.ext?.data?.pagetype).to.deep.equals('my-page');
@@ -400,7 +390,7 @@ describe('Prebid First Party Data Module', () => {
       });
 
       it('should write unique values', async () => {
-        const module = createFpdModule({}, { cat: 'openrtb2_cat' });
+        const { configureStep } = createFpdModule({}, { cat: 'openrtb2_cat' });
 
         const moliConfig: MoliConfig = configWithTargeting({
           keyValues: {
@@ -415,7 +405,7 @@ describe('Prebid First Party Data Module', () => {
           }
         });
 
-        await module.configureSteps()[0](adPipelineContext(moliConfig), []);
+        await configureStep(adPipelineContext(moliConfig), []);
         expect(setConfigSpy).to.have.been.calledOnce;
         const site = setConfigSpy.firstCall.firstArg.ortb2.site as OpenRtb2Site;
         expect(site.cat).to.deep.equals(['IAB-1']);


### PR DESCRIPTION
Fallback to the top level private domain as a iabProviderName if none is provided in the config.