### PR TITLE
Use runtime ad unit path variables

### DIFF
--- a/ad-tag/source/ts/ads/adPipeline.ts
+++ b/ad-tag/source/ts/ads/adPipeline.ts
@@ -366,12 +366,17 @@ export class AdPipeline {
           ? config.buckets.bucket[bucketName]
           : null;
 
-      const adUnitPathVariables = generateAdUnitPathVariables(
+      const defaultAdUnitPathVariables = generateAdUnitPathVariables(
         this.window.location.hostname,
         labelConfigService.getDeviceLabel(),
         config.targeting?.adUnitPathVariables,
         config.domain
       );
+
+      const adUnitPathVariables = {
+        ...defaultAdUnitPathVariables,
+        ...runtimeConfig.adUnitPathVariables
+      };
 
       // the context is based on the consent data
       const context: AdPipelineContext = {


### PR DESCRIPTION
The `setAdUnitPathVariables` API had no effect.