### PR TITLE
Add loaded options in refreshBucket call

### DIFF
--- a/ad-tag/source/ts/ads/modules/ad-reload/index.test.ts
+++ b/ad-tag/source/ts/ads/modules/ad-reload/index.test.ts
@@ -715,6 +715,7 @@ describe('Moli Ad Reload Module', () => {
 
         expect(setTargetingSpy).to.have.been.calledOnceWithExactly('native-ad-reload', 'true');
         expect(refreshBucketSpy).to.have.been.calledOnce;
+        expect(refreshBucketSpy).to.have.been.calledOnceWithExactly('page', { loaded: 'eager' });
       });
     });
   });


### PR DESCRIPTION
Fix ad reload if `refreshBucket` is true and the bucket contains `eager` loaded slots.