### PR TITLE
Do not stretch to the full height

### DIFF
--- a/ad-tag/source/css/basic/content.css
+++ b/ad-tag/source/css/basic/content.css
@@ -1,6 +1,7 @@
 .h5v-content {
   display: flex;
-  justify-content: center;
+  flex-direction: column;
+  align-items: center;
 
   /** sticky content */
   & > div {


### PR DESCRIPTION
This allows the stickyness inside the content slots to properly work