### PR TITLE
Use navbar height var for sticky content top calculation

### DIFF
--- a/ad-tag/source/css/basic/content.css
+++ b/ad-tag/source/css/basic/content.css
@@ -5,7 +5,7 @@
 
   /** sticky content */
   & > div {
-    top: 0;
+    top: var(--h5v-navbar-height);
     position: sticky;
   }
 


### PR DESCRIPTION
Otherwise sticky content slots may get hidden under a sticky navbar