### PR TITLE
Tighten disableLegitimateInterest implementation

### DIFF
--- a/ad-tag/source/ts/ads/consent.test.ts
+++ b/ad-tag/source/ts/ads/consent.test.ts
@@ -106,12 +106,8 @@ describe('consent', () => {
       tcDataWithMissingConsent.purpose.consents[TCPurpose.STORE_INFORMATION_ON_DEVICE] = false;
       tcDataWithMissingConsent.purpose.legitimateInterests[TCPurpose.STORE_INFORMATION_ON_DEVICE] =
         false;
-      it('should return always false for purpose 1 (STORE_INFORMATION_ON_DEVICE)', () => {
-        expect(missingPurposeConsent(tcDataWithMissingConsent)).to.be.false;
-      });
-
-      it('should reject consentReady if consent is missing for purpose 1 (STORE_INFORMATION_ON_DEVICE)', () => {
-        expect(missingPurposeConsent(tcDataWithMissingConsent)).to.be.false;
+      it('should return always true for purpose 1 (STORE_INFORMATION_ON_DEVICE)', () => {
+        expect(missingPurposeConsent(tcDataWithMissingConsent)).to.be.true;
       });
     });
 
@@ -139,6 +135,29 @@ describe('consent', () => {
           expect(cmd).to.be.equals('addEventListener');
           expect(version).to.be.equals(2);
           callback(tcDataWithMissingConsent, true);
+        });
+
+        await expect(
+          consentReady(consentConfig, jsDomWindow, noopLogger, 'production')
+        ).to.be.rejectedWith('user consent is missing for some purposes');
+      });
+
+      it(`should return true consent and legitimate interest is missing for purpose ${purpose} (${TCPurpose[purpose]})`, () => {
+        const tcDataWithMissingConsentAndLI: tcfapi.responses.TCData = fullConsent();
+        tcDataWithMissingConsentAndLI.purpose.consents[purpose] = false;
+        tcDataWithMissingConsentAndLI.purpose.legitimateInterests[purpose] = false;
+
+        expect(missingPurposeConsent(tcDataWithMissingConsentAndLI)).to.be.true;
+      });
+
+      it(`should reject consentReady if consent and legitimate interest is missing for purpose ${purpose} (${TCPurpose[purpose]}), but available as legitimate interest`, async () => {
+        tcfapiFn.onFirstCall().callsFake((cmd, version, callback) => {
+          expect(cmd).to.be.equals('addEventListener');
+          expect(version).to.be.equals(2);
+          const tcDataWithMissingConsentAndLI: tcfapi.responses.TCData = fullConsent();
+          tcDataWithMissingConsentAndLI.purpose.consents[purpose] = false;
+          tcDataWithMissingConsentAndLI.purpose.legitimateInterests[purpose] = false;
+          callback(tcDataWithMissingConsentAndLI, true);
         });
 
         await expect(

--- a/ad-tag/source/ts/ads/consent.ts
+++ b/ad-tag/source/ts/ads/consent.ts
@@ -19,7 +19,7 @@ const allPurposes: tcfapi.responses.TCPurpose[] = [
 
 /**
  * This method returns false as soon as there's at least one purpose where
- * legitimate interest is available, but consent is not.
+ * consent is missing, regardless of whether the legitimate interest is set or not.
  *
  * @param tcData
  */
@@ -28,7 +28,7 @@ export const missingPurposeConsent = (tcData: tcfapi.responses.TCData): boolean 
     // gdpr must apply
     !!tcData.gdprApplies &&
     // for all purposes
-    allPurposes.some(p => !tcData.purpose.consents[p] && tcData.purpose.legitimateInterests[p])
+    allPurposes.some(p => !tcData.purpose.consents[p])
   );
 };
 


### PR DESCRIPTION
All purposes are required to sent ads.

This is a bit heavy, but gives some publishers the good sleep they deserve.
We may make this more granular in the future. It's the killswitch