### PR TITLE
override loader also works for manual slots

### DIFF
--- a/ad-tag/source/ts/ads/adService.test.ts
+++ b/ad-tag/source/ts/ads/adService.test.ts
@@ -1009,6 +1009,48 @@ describe('AdService', () => {
       );
     });
 
+    it('should call adPipeline.run with the slot if slot is manual and in the DOM', async () => {
+      const adService = makeAdService();
+      const slot = manualAdSlot();
+      const configWithManualSlot: MoliConfig = {
+        ...emptyConfig,
+        slots: [slot]
+      };
+      addToDom([slot]);
+      const runSpy = sandbox.spy(adService.getAdPipeline(), 'run');
+      await adService.refreshAdSlots([slot.domId], configWithManualSlot, emptyRuntimeConfig, {
+        loaded: 'manual'
+      });
+      expect(runSpy).to.have.been.calledOnce;
+      expect(runSpy).to.have.been.calledWithExactly(
+        [slot],
+        configWithManualSlot,
+        emptyRuntimeConfig,
+        Sinon.match.number
+      );
+    });
+
+    it('should call adPipeline.run with the slot if slot is manual and in the DOM and the override option is manual', async () => {
+      const adService = makeAdService();
+      const slot: AdSlot = manualAdSlot();
+      const configWithManualSlot: MoliConfig = {
+        ...emptyConfig,
+        slots: [slot]
+      };
+      addToDom([slot]);
+      const runSpy = sandbox.spy(adService.getAdPipeline(), 'run');
+      await adService.refreshAdSlots([slot.domId], configWithManualSlot, emptyRuntimeConfig, {
+        loaded: 'eager'
+      });
+      expect(runSpy).to.have.been.calledOnce;
+      expect(runSpy).to.have.been.calledWithExactly(
+        [slot],
+        configWithManualSlot,
+        emptyRuntimeConfig,
+        Sinon.match.number
+      );
+    });
+
     it('should call adPipeline.run with updates slots with the options.sizesOverride', async () => {
       const adService = makeAdService();
       const slot: AdSlot = {

--- a/ad-tag/source/ts/ads/adService.ts
+++ b/ad-tag/source/ts/ads/adService.ts
@@ -406,11 +406,19 @@ export class AdService {
 
     const { loaded } = { ...{ loaded: 'manual' }, ...options };
 
+    const allowedLoadingBehaviours = new Set<behaviour.ISlotLoading['loaded']>(['infinite']);
+    if (loaded === 'eager') {
+      allowedLoadingBehaviours.add('manual');
+      allowedLoadingBehaviours.add('eager');
+    } else {
+      allowedLoadingBehaviours.add(loaded as behaviour.ISlotLoading['loaded']);
+    }
+
     const availableSlots = config.slots
       .filter(
         slot =>
           domIds.some(domId => domId === slot.domId) &&
-          (slot.behaviour.loaded === loaded || slot.behaviour.loaded === 'infinite')
+          allowedLoadingBehaviours.has(slot.behaviour.loaded)
       )
       .filter(isSlotAvailable(this.window))
       // if sizesOverride is provided, override the sizes of the slots


### PR DESCRIPTION
This change allows ad slots to be loaded with an override option of `eager` to also be triggered if the ad slot has `manual` loading behaviour.

That change smoothens migrations from eager loading to lazy loading behaviour with custom refresh implementations.