### PR TITLE
check ad unit path for all configs

### DIFF
--- a/ad-tag/source/ts/ads/auctions/frequencyCapping.ts
+++ b/ad-tag/source/ts/ads/auctions/frequencyCapping.ts
@@ -217,26 +217,27 @@ export class FrequencyCapping {
   }
 
   isAdUnitCapped(adUnitPath: string): boolean {
-    return this.resolvedAdUnitPathPositionConfigs.some(positionConfig => {
-      return (
-        (positionConfig.adUnitPath === adUnitPath &&
+    return this.resolvedAdUnitPathPositionConfigs
+      .filter(config => config.adUnitPath === adUnitPath)
+      .some(positionConfig => {
+        return (
           // cap if minRequestAds is not reached yet
-          positionConfig.conditions.delay &&
-          this.numAdRequests < positionConfig.conditions.delay.minRequestAds) ||
-        // cap if not at the right pacing interval yet
-        (positionConfig.conditions.pacingRequestAds &&
-          // if there are no winning impressions yet, we can request ads
-          this.positionLastImpressionNumberOfAdRequests.has(adUnitPath) &&
-          // check if enough ad requests were made since the last impression
-          this.numAdRequests -
-            (this.positionLastImpressionNumberOfAdRequests.get(adUnitPath) ?? 0) <
-            positionConfig.conditions.pacingRequestAds.requestAds) ||
-        // cap if the maxImpressions is reached in the current window
-        (positionConfig.conditions.pacingInterval &&
-          (this.positionImpSchedules.get(adUnitPath) ?? []).length >=
-            positionConfig.conditions.pacingInterval.maxImpressions)
-      );
-    });
+          (positionConfig.conditions.delay &&
+            this.numAdRequests < positionConfig.conditions.delay.minRequestAds) ||
+          // cap if not at the right pacing interval yet
+          (positionConfig.conditions.pacingRequestAds &&
+            // if there are no winning impressions yet, we can request ads
+            this.positionLastImpressionNumberOfAdRequests.has(adUnitPath) &&
+            // check if enough ad requests were made since the last impression
+            this.numAdRequests -
+              (this.positionLastImpressionNumberOfAdRequests.get(adUnitPath) ?? 0) <
+              positionConfig.conditions.pacingRequestAds.requestAds) ||
+          // cap if the maxImpressions is reached in the current window
+          (positionConfig.conditions.pacingInterval &&
+            (this.positionImpSchedules.get(adUnitPath) ?? []).length >=
+              positionConfig.conditions.pacingInterval.maxImpressions)
+        );
+      });
   }
 
   isFrequencyCapped(slotId: string, bidder: BidderCode): boolean {


### PR DESCRIPTION
This was not a bug, because all other checks covered the ad unit path filtering.
However this makes the implementation way more obvious and maybe a little bit more performant