### PR TITLE
Select last auction winner for cleanup check

### DIFF
--- a/ad-tag/source/ts/ads/modules/cleanup/index.ts
+++ b/ad-tag/source/ts/ads/modules/cleanup/index.ts
@@ -181,10 +181,12 @@ export class Cleanup implements IModule {
     context: AdPipelineContext,
     config: modules.cleanup.CleanupConfig
   ): boolean => {
+    // get the all winning bids from PrebidJS and filter for the last winning bid on the configured slot
     const prebidWinningBids = context.window__.pbjs.getAllWinningBids();
-    const bidderThatWonLastAuctionOnSlot = prebidWinningBids.find(
-      bid => bid.adUnitCode === config.domId
-    )?.bidder;
+    const bidderThatWonLastAuctionOnSlot = prebidWinningBids
+      .filter(bid => bid.adUnitCode === config.domId)
+      .at(-1)?.bidder;
+
     // look at the single cleanup config and check if the configured bidder has won the last auction on the configured slot
     return bidderThatWonLastAuctionOnSlot === config.bidder;
   };


### PR DESCRIPTION
The `pbjs.getAllWinningBids` returns, well, all winning bids 😁  Of all auctions that have happened so far.
I'm still not sure if this is the most robust way, as prebid.js does seem to have some cleanup logic.

Still this fixes an issue were we call the wrong cleanup functions, because we take the first not the last auction.