### PR TITLE
Add more cleanup steps to support different single page app behaviours

### DIFF
--- a/ad-tag/source/ts/ads/adService.ts
+++ b/ad-tag/source/ts/ads/adService.ts
@@ -27,6 +27,7 @@ import {
 } from './googleAdManager';
 import domready from '../util/domready';
 import {
+  prebidClearAuction,
   prebidConfigure,
   prebidDefineSlots,
   prebidInit,
@@ -198,6 +199,9 @@ export class AdService {
       configure.push(prebidConfigure(config.prebid, config.schain));
       if (isSinglePageApp) {
         configure.push(prebidRemoveAdUnits(config.prebid));
+        if (config.prebid.clearAllAuctions) {
+          configure.push(prebidClearAuction());
+        }
       }
       prepareRequestAds.push(prebidPrepareRequestAds(config.prebid));
       requestBids.push(prebidRequestBids(config.prebid, adServer, config.targeting));

--- a/ad-tag/source/ts/stubs/prebidjsStubs.ts
+++ b/ad-tag/source/ts/stubs/prebidjsStubs.ts
@@ -87,6 +87,12 @@ export const createPbjsStub = (): prebidjs.IPrebidJs => {
     getAllWinningBids(): prebidjs.BidResponse[] {
       return [];
     },
+    getBidResponsesForAdUnitCode(adUnitCode: string): prebidjs.IBidsResponse {
+      return { bids: [] };
+    },
+    clearAllAuctions(): void {
+      return;
+    },
     aliasBidder(
       bidderCode: string,
       alias: string,

--- a/ad-tag/source/ts/types/moli.ts
+++ b/ad-tag/source/ts/types/moli.ts
@@ -1008,6 +1008,73 @@ export namespace Moli {
   }
 
   /**
+   * Default cleanup behaviour for single page applications.
+   * All slots are being destroyed on navigation.
+   */
+  export interface SinglePageAppCleanupConfigAll {
+    readonly slots: 'all';
+  }
+
+  /**
+   * This cleanup configuration destroys only the ad slots that are requested after navigation.
+   * Replacement for the old `destroyAllAdSlots` setting.
+   *
+   * It allows publishers to keep all ad slots alive on navigation and only destroy the ones
+   * that are requested.
+   *
+   * Use with caution and test properly.
+   *
+   * ## Use cases
+   *
+   * This setting can be used for publishers that have more "static" ad slots, like
+   * mobile sticky, footer ad or skyscraper that should not be destroyed on every page navigation
+   * and that have users that navigation a lot on the page, e.g. swiping through images or profiles.
+   * With this setting the more persistent ad slots are refreshed through ad reload or timed by the
+   * publisher, while other content positions are refreshed on navigation.
+   */
+  export interface SinglePageAppCleanupConfigRequested {
+    readonly slots: 'requested';
+  }
+
+  /**
+   * This cleanup configuration allows publishers to select which ad slots should not be destroyed
+   * on navigation. Currently only the `excluded` option is supported, which means that all ad slots
+   * are destroyed on navigation, except the ones listed in `slotIds`.
+   *
+   * ## Use cases
+   *
+   * There are a couple of use cases for this setting.
+   *
+   * ### Static out-of-content ad slots
+   *
+   * Sidebars or sticky footers that are always present are handled by the regular ad reload.
+   * Especially if the user navigates a lot on the page, e.g. swiping through images or profiles,
+   * this leads to a better user experience and advertiser performance as ad refreshing is less frequent.
+   *
+   * ### Render on navigation slots like interstitials
+   *
+   * Certain slots are rendered on navigation, e.g. interstitials that are shown on navigation.
+   * Those slots should not be destroyed on navigation, to be able to render them properly.
+   */
+  export interface SinglePageAppCleanupConfigSelected {
+    /**
+     * excluded: a list of ad slots that should not be destroyed on navigation.
+     *
+     * Note: This might be extended the future to support including only certain slots.
+     */
+    readonly slots: 'excluded';
+    /**
+     * A list of ad slot IDs that should not be destroyed on navigation.
+     */
+    readonly slotIds: string[];
+  }
+
+  export type SinglePageAppCleanupConfig =
+    | SinglePageAppCleanupConfigAll
+    | SinglePageAppCleanupConfigRequested
+    | SinglePageAppCleanupConfigSelected;
+
+  /**
    * Additional configuration for single page application publishers.
    */
   export interface SinglePageAppConfig {
@@ -1017,22 +1084,9 @@ export namespace Moli {
     readonly enabled: boolean;
 
     /**
-     * If set to `false`, `requestAds` will not destroy all existing ad slots,
-     * but only the ones being requested.
-     *
-     * Use with caution and test properly.
-     *
-     * ## Use cases
-     *
-     * This setting can be used for publishers that have more "static" ad slots, like
-     * mobile sticky, footer ad or skyscraper that should not be destroyed on every page navigation
-     * and that have users that navigation a lot on the page, e.g. swiping through images or profiles.
-     * With this setting the more persistent ad slots are refreshed through ad reload or timed by the
-     * publisher, while other content positions are refreshed on navigation.
-     *
-     * @default true
+     * Defines the cleanup behaviour on navigation.
      */
-    readonly destroyAllAdSlots?: boolean;
+    readonly cleanup?: SinglePageAppCleanupConfig;
 
     /**
      * If set to `href`
@@ -1865,6 +1919,17 @@ export namespace Moli {
 
       /** External prebid distribution url */
       readonly distributionUrl?: string;
+
+      /**
+       * If set to true, the prebid auction will be clear on every `requestAds` call.
+       * This can be useful in single page applications where the ad slots are reused.
+       *
+       * By default, this is false and the prebid auction will not be cleared.
+       * Make sure if you enable this, to monitor the impact.
+       *
+       * @default false
+       */
+      readonly clearAllAuctions?: boolean;
     }
 
     /**

--- a/ad-tag/source/ts/types/prebidjs.ts
+++ b/ad-tag/source/ts/types/prebidjs.ts
@@ -243,6 +243,26 @@ export namespace prebidjs {
     getAllWinningBids(): prebidjs.BidResponse[];
 
     /**
+     * This function returns the bid responses at the given moment.
+     *
+     * Note that prebidjs doesn't clean up old bid responses, so this function will return all bid responses
+     * over time. You have to use clearAllAuctions() to clear the bid responses.
+     *
+     * @param adUnitCode
+     * @see https://docs.prebid.org/dev-docs/publisher-api-reference/getBidResponsesForAdUnitCode.html
+     * @see https://docs.prebid.org/dev-docs/publisher-api-reference/getBidResponses.html
+     */
+    getBidResponsesForAdUnitCode(adUnitCode: string): IBidsResponse;
+
+    /**
+     * Utility to clear all ad units of bids. This is useful for testing or to clear caches in a
+     * single page application.
+     *
+     * @see https://docs.prebid.org/dev-docs/publisher-api-reference/clearAllAuctions.html
+     */
+    clearAllAuctions(): void;
+
+    /**
      * Defining an alias can help avoid user confusion since it’s possible to send parameters to the same adapter
      * but in different contexts (e.g, The publisher uses "appnexus" for demand and also uses "newAlias" which is an
      * SSP partner that uses the "appnexus" adapter to serve their own unique demand).
@@ -5707,6 +5727,10 @@ export namespace prebidjs {
     readonly auctionId: string;
   }
 
+  export interface IBidsResponse {
+    bids: prebidjs.BidResponse[];
+  }
+
   /**
    * The Object returned by the bidsBackHandler when requesting the Prebidjs bids.
    */
@@ -5714,14 +5738,7 @@ export namespace prebidjs {
     /**
      * The adUnit code, e.g. 'ad-presenter-desktop'
      */
-    [adUnitCode: string]:
-      | {
-          /**
-           * The bids that were returned by prebid
-           */
-          bids: prebidjs.BidResponse[];
-        }
-      | undefined;
+    [adUnitCode: string]: IBidsResponse | undefined;
   }
 
   /**


### PR DESCRIPTION
This commit adds a two new main settings to control cleanup behaviour during page navigation in single page applications.

- prebid.clearAllAuctions - This calls the pbjs.clearAllAuctions method, which resets a lot of internal state in prebid, that may cause strange behaviours and memory leaks
- spa.cleanup - This configuration property gives more granular access to what slots are destroyed during page navigation. It replaces the rough destroyAllAdSlots setting