### PR TITLE
Do not stop pipeline if zero ad slots are requested

### DIFF
--- a/ad-tag/source/ts/ads/adPipeline.test.ts
+++ b/ad-tag/source/ts/ads/adPipeline.test.ts
@@ -107,7 +107,7 @@ describe('AdPipeline', () => {
   });
 
   describe('run', () => {
-    it('should not run when the slots array is empty', async () => {
+    it('should run when the slots array is empty to initialize modules', async () => {
       let callCount: number = 0;
       const initSteps: InitStep[] = [
         () => {
@@ -117,7 +117,7 @@ describe('AdPipeline', () => {
       ];
       const pipeline = newAdPipeline({ ...emptyPipelineConfig, init: initSteps });
       await pipeline.run([], emptyConfig, emptyRuntimeConfig, 1);
-      expect(callCount).to.be.equals(0);
+      expect(callCount).to.be.equals(1);
     });
 
     it('should use the proper timeout', () => {

--- a/ad-tag/source/ts/ads/adPipeline.ts
+++ b/ad-tag/source/ts/ads/adPipeline.ts
@@ -340,10 +340,6 @@ export class AdPipeline {
     requestAdsCalls: number,
     options?: IAdPipelineRunOptions
   ): Promise<void> {
-    if (slots.length === 0) {
-      return Promise.resolve();
-    }
-
     // increase the prebid request count
     this.requestId = this.requestId + 1;
     const currentRequestId = this.requestId;


### PR DESCRIPTION
This was added long ago for no apparent reason.

The pipeline needs to run fully until the requestBids step to initialize lazy loading listeners and other things