### PR TITLE
Adjust frequency capping for gam interstitial format

### DIFF
--- a/ad-tag/source/ts/ads/a9.test.ts
+++ b/ad-tag/source/ts/ads/a9.test.ts
@@ -368,8 +368,8 @@ describe('a9', () => {
       const slot2 = createSlotDefinitions(domId2, {});
 
       const isThrottled = sandbox.stub(contextWithConsent.auction__, 'isSlotThrottled');
-      isThrottled.withArgs(domId1, slot1.adSlot.getAdUnitPath()).returns(false);
-      isThrottled.withArgs(domId2, slot2.adSlot.getAdUnitPath()).returns(true);
+      isThrottled.withArgs(slot1.adSlot).returns(false);
+      isThrottled.withArgs(slot2.adSlot).returns(true);
 
       await step(contextWithConsent, [slot1, slot2]);
       expect(addAdUnitsSpy).to.have.been.calledOnce;

--- a/ad-tag/source/ts/ads/a9.ts
+++ b/ad-tag/source/ts/ads/a9.ts
@@ -218,10 +218,7 @@ export const a9RequestBids = (config: headerbidding.A9Config): RequestBidsStep =
 
         const slots = slotDefinitions
           .filter(isA9SlotDefinition)
-          .filter(
-            slot =>
-              !context.auction__.isSlotThrottled(slot.moliSlot.domId, slot.adSlot.getAdUnitPath())
-          )
+          .filter(slot => !context.auction__.isSlotThrottled(slot.adSlot))
           .filter(slot => {
             const isVideo = slot.moliSlot.a9.mediaType === 'video';
             const filterSlot = context.labelConfigService__.filterSlot(slot.moliSlot.a9);

--- a/ad-tag/source/ts/ads/auctions/frequencyCapping.test.ts
+++ b/ad-tag/source/ts/ads/auctions/frequencyCapping.test.ts
@@ -12,7 +12,8 @@ import BidResponse = prebidjs.BidResponse;
 import { auction } from 'ad-tag/types/moliConfig';
 import { newNoopLogger, noopLogger } from 'ad-tag/stubs/moliStubs';
 import { googletag } from 'ad-tag/types/googletag';
-import { googleAdSlotStub } from 'ad-tag/stubs/googletagStubs';
+import { createGoogletagStub, googleAdSlotStub } from 'ad-tag/stubs/googletagStubs';
+import { formatKey } from 'ad-tag/ads/keyValues';
 use(sinonChai);
 
 describe('FrequencyCapping', () => {
@@ -25,6 +26,7 @@ describe('FrequencyCapping', () => {
 
   const wpDomId = 'wp-slot';
   const wpAdUnitPath = '/123,456/example/wp-slot';
+  const wpSlot = googleAdSlotStub(wpAdUnitPath, wpDomId);
   const dspxWpConfig: auction.BidderFrequencyCappingConfig = {
     bidders: [prebidjs.DSPX],
     domId: wpDomId,
@@ -34,6 +36,8 @@ describe('FrequencyCapping', () => {
   };
 
   const interstitialDomId = 'interstitial';
+  const interstitialAdUnitPath = '/123,456/example/interstitial';
+  const interstitalSlot = googleAdSlotStub(interstitialAdUnitPath, interstitialDomId);
   const visxInterstitialConfig: auction.BidderFrequencyCappingConfig = {
     bidders: [prebidjs.Visx],
     domId: interstitialDomId,
@@ -60,31 +64,14 @@ describe('FrequencyCapping', () => {
 
   const slotRenderEndedEvent = (
     isEmpty: boolean,
-    adUnitPath: string,
-    format?: string
+    slot: googletag.IAdSlot
   ): googletag.events.ISlotRenderEndedEvent =>
-    ({
-      isEmpty,
-      slot: {
-        getAdUnitPath: () => adUnitPath,
-        getTargeting(key: string): string[] {
-          return key === 'f' && format ? [format] : [];
-        }
-      }
-    }) as googletag.events.ISlotRenderEndedEvent;
+    ({ isEmpty, slot }) as googletag.events.ISlotRenderEndedEvent;
 
   const impressionViewableEvent = (
-    adUnitPath: string,
-    format?: string
+    slot: googletag.IAdSlot
   ): googletag.events.IImpressionViewableEvent =>
-    ({
-      slot: {
-        getAdUnitPath: () => adUnitPath,
-        getTargeting(key: string): string[] {
-          return key === 'f' && format ? [format] : [];
-        }
-      }
-    }) as googletag.events.IImpressionViewableEvent;
+    ({ slot }) as googletag.events.IImpressionViewableEvent;
 
   after(() => {
     // bring everything back to normal after tests
@@ -94,11 +81,14 @@ describe('FrequencyCapping', () => {
   beforeEach(() => {
     sandbox.useFakeTimers();
     jsDomWindow.sessionStorage.clear();
+    jsDomWindow.googletag = createGoogletagStub();
   });
 
   afterEach(() => {
     sandbox.reset();
     sandbox.clock.restore();
+    wpSlot.clearTargeting();
+    interstitalSlot.clearTargeting();
   });
 
   it('should not add a frequency cap if configs are empty', () => {
@@ -108,7 +98,7 @@ describe('FrequencyCapping', () => {
       nowInstantStub,
       noopLogger
     );
-    expect(frequencyCapping.isFrequencyCapped('wp-slot', prebidjs.DSPX)).to.be.false;
+    expect(frequencyCapping.isBidderCapped('wp-slot', prebidjs.DSPX)).to.be.false;
     expect(jsDomWindow.sessionStorage.getItem('h5v-fc')).to.be.null;
   });
 
@@ -119,7 +109,7 @@ describe('FrequencyCapping', () => {
       nowInstantStub,
       noopLogger
     );
-    expect(frequencyCapping.isFrequencyCapped(dspxWpConfig.domId, prebidjs.DSPX)).to.be.false;
+    expect(frequencyCapping.isBidderCapped(dspxWpConfig.domId, prebidjs.DSPX)).to.be.false;
     expect(jsDomWindow.sessionStorage.getItem('h5v-fc'));
   });
 
@@ -138,7 +128,7 @@ describe('FrequencyCapping', () => {
       it('should not add a frequency cap if the slot id does not match', () => {
         frequencyCapping.onBidWon(dspxBidResponse);
 
-        expect(frequencyCapping.isFrequencyCapped('unrelated-slot', prebidjs.DSPX)).to.be.false;
+        expect(frequencyCapping.isBidderCapped('unrelated-slot', prebidjs.DSPX)).to.be.false;
       });
 
       it('should not add a frequency cap if the slot id does not match and a delay is configured for all bidders', () => {
@@ -153,7 +143,7 @@ describe('FrequencyCapping', () => {
         );
         frequencyCappingWithDelay.onBidWon(dspxBidResponse);
 
-        expect(frequencyCappingWithDelay.isFrequencyCapped('unrelated-slot', prebidjs.DSPX)).to.be
+        expect(frequencyCappingWithDelay.isBidderCapped('unrelated-slot', prebidjs.DSPX)).to.be
           .false;
       });
 
@@ -175,7 +165,7 @@ describe('FrequencyCapping', () => {
         );
         frequencyCappingWithDelay.onBidWon(dspxBidResponse);
 
-        expect(frequencyCappingWithDelay.isFrequencyCapped('unrelated-slot', prebidjs.DSPX)).to.be
+        expect(frequencyCappingWithDelay.isBidderCapped('unrelated-slot', prebidjs.DSPX)).to.be
           .false;
       });
 
@@ -184,22 +174,22 @@ describe('FrequencyCapping', () => {
 
         frequencyCapping.onBidWon(bid);
 
-        expect(frequencyCapping.isFrequencyCapped(wpDomId, prebidjs.DSPX)).to.be.false;
+        expect(frequencyCapping.isBidderCapped(wpDomId, prebidjs.DSPX)).to.be.false;
       });
 
       it('should add a frequency cap when a bid is won on the configured slot', () => {
         frequencyCapping.onBidWon(dspxBidResponse);
-        expect(frequencyCapping.isFrequencyCapped(wpDomId, prebidjs.DSPX)).to.be.true;
+        expect(frequencyCapping.isBidderCapped(wpDomId, prebidjs.DSPX)).to.be.true;
       });
 
       it('should remove the frequency cap after the specified timeout', () => {
         nowInstantStub.returns(100000);
         frequencyCapping.onBidWon(dspxBidResponse);
-        expect(frequencyCapping.isFrequencyCapped(wpDomId, prebidjs.DSPX)).to.be.true;
+        expect(frequencyCapping.isBidderCapped(wpDomId, prebidjs.DSPX)).to.be.true;
 
         sandbox.clock.tick(11000);
         expect(setTimeoutSpy).to.have.been.calledOnceWithExactly(Sinon.match.func, 10000);
-        expect(frequencyCapping.isFrequencyCapped(wpDomId, prebidjs.DSPX)).to.be.false;
+        expect(frequencyCapping.isBidderCapped(wpDomId, prebidjs.DSPX)).to.be.false;
       });
     });
 
@@ -215,13 +205,13 @@ describe('FrequencyCapping', () => {
       });
 
       it('should not add a frequency cap if no events have been fired', () => {
-        expect(frequencyCapping.isFrequencyCapped(interstitialDomId, prebidjs.Visx)).to.be.false;
+        expect(frequencyCapping.isBidderCapped(interstitialDomId, prebidjs.Visx)).to.be.false;
       });
 
       it('should not add a frequency cap if the configured bidder did not request a bid on the slot', () => {
         frequencyCapping.onAuctionEnd(auction([]));
 
-        expect(frequencyCapping.isFrequencyCapped(interstitialDomId, prebidjs.Visx)).to.be.false;
+        expect(frequencyCapping.isBidderCapped(interstitialDomId, prebidjs.Visx)).to.be.false;
       });
 
       it('should add a frequency cap when a bid is requested on the configured slot', () => {
@@ -229,18 +219,18 @@ describe('FrequencyCapping', () => {
           auction([{ bidder: prebidjs.Visx, adUnitCode: interstitialDomId }])
         );
 
-        expect(frequencyCapping.isFrequencyCapped(interstitialDomId, prebidjs.Visx)).to.be.true;
+        expect(frequencyCapping.isBidderCapped(interstitialDomId, prebidjs.Visx)).to.be.true;
       });
 
       it('should remove the frequency cap after the specified timeout', () => {
         frequencyCapping.onAuctionEnd(
           auction([{ bidder: prebidjs.Visx, adUnitCode: interstitialDomId }])
         );
-        expect(frequencyCapping.isFrequencyCapped(interstitialDomId, prebidjs.Visx)).to.be.true;
+        expect(frequencyCapping.isBidderCapped(interstitialDomId, prebidjs.Visx)).to.be.true;
 
         sandbox.clock.tick(11000);
         expect(setTimeoutSpy).to.have.been.calledOnceWithExactly(Sinon.match.func, 10000);
-        expect(frequencyCapping.isFrequencyCapped(interstitialDomId, prebidjs.Visx)).to.be.false;
+        expect(frequencyCapping.isBidderCapped(interstitialDomId, prebidjs.Visx)).to.be.false;
       });
     });
   });
@@ -261,20 +251,42 @@ describe('FrequencyCapping', () => {
         ]);
 
         frequencyCapping.afterRequestAds();
-        expect(frequencyCapping.isAdUnitCapped(wpAdUnitPath)).to.be.true;
+        expect(frequencyCapping.isAdUnitCapped(wpSlot)).to.be.true;
       });
 
       it('should not frequency cap if the slot has a delay configured but the minimum request ads have been reached', () => {
         const frequencyCapping = makeFrequencyCapping([
           { adUnitPath: wpAdUnitPath, conditions: { delay: { minRequestAds: 2 } } }
         ]);
-        expect(frequencyCapping.isAdUnitCapped(wpAdUnitPath)).to.be.true;
+        expect(frequencyCapping.isAdUnitCapped(wpSlot)).to.be.true;
 
         frequencyCapping.afterRequestAds();
-        expect(frequencyCapping.isAdUnitCapped(wpAdUnitPath)).to.be.true;
+        expect(frequencyCapping.isAdUnitCapped(wpSlot)).to.be.true;
 
         frequencyCapping.afterRequestAds();
-        expect(frequencyCapping.isAdUnitCapped(wpAdUnitPath)).to.be.false;
+        expect(frequencyCapping.isAdUnitCapped(wpSlot)).to.be.false;
+      });
+
+      describe('google web interstitial format', () => {
+        it('should reduce minRequestAds delay by one  if the format is interstitial', () => {
+          const frequencyCapping = makeFrequencyCapping([
+            { adUnitPath: interstitialAdUnitPath, conditions: { delay: { minRequestAds: 1 } } }
+          ]);
+          const format = googletag.enums.OutOfPageFormat.INTERSTITIAL.toString();
+          interstitalSlot.setTargeting(formatKey, format);
+
+          expect(frequencyCapping.isAdUnitCapped(interstitalSlot)).to.be.false;
+        });
+
+        it('should not reduce minRequestAds delay if the format is not interstitial', () => {
+          const frequencyCapping = makeFrequencyCapping([
+            { adUnitPath: wpAdUnitPath, conditions: { delay: { minRequestAds: 1 } } }
+          ]);
+          const format = googletag.enums.OutOfPageFormat.BOTTOM_ANCHOR.toString();
+          wpSlot.setTargeting(formatKey, format);
+
+          expect(frequencyCapping.isAdUnitCapped(wpSlot)).to.be.true;
+        });
       });
     });
 
@@ -284,12 +296,12 @@ describe('FrequencyCapping', () => {
           { adUnitPath: wpAdUnitPath, conditions: { pacingRequestAds: { requestAds: 2 } } }
         ]);
 
-        expect(frequencyCapping.isAdUnitCapped(wpAdUnitPath)).to.be.false;
-        frequencyCapping.onSlotRenderEnded(slotRenderEndedEvent(false, wpAdUnitPath));
+        expect(frequencyCapping.isAdUnitCapped(wpSlot)).to.be.false;
+        frequencyCapping.onSlotRenderEnded(slotRenderEndedEvent(false, wpSlot));
         frequencyCapping.afterRequestAds();
-        expect(frequencyCapping.isAdUnitCapped(wpAdUnitPath)).to.be.true;
+        expect(frequencyCapping.isAdUnitCapped(wpSlot)).to.be.true;
         frequencyCapping.afterRequestAds();
-        expect(frequencyCapping.isAdUnitCapped(wpAdUnitPath)).to.be.false;
+        expect(frequencyCapping.isAdUnitCapped(wpSlot)).to.be.false;
       });
 
       it('should use slotRenderEnded events for pacing by request ads if the format is not interstitial', () => {
@@ -297,40 +309,42 @@ describe('FrequencyCapping', () => {
           { adUnitPath: wpAdUnitPath, conditions: { pacingRequestAds: { requestAds: 2 } } }
         ]);
         const format = googletag.enums.OutOfPageFormat.BOTTOM_ANCHOR.toString();
+        wpSlot.setTargeting(formatKey, format);
 
-        expect(frequencyCapping.isAdUnitCapped(wpAdUnitPath)).to.be.false;
-        frequencyCapping.onSlotRenderEnded(slotRenderEndedEvent(false, wpAdUnitPath, format));
+        expect(frequencyCapping.isAdUnitCapped(wpSlot)).to.be.false;
+        frequencyCapping.onSlotRenderEnded(slotRenderEndedEvent(false, wpSlot));
         frequencyCapping.afterRequestAds();
 
-        expect(frequencyCapping.isAdUnitCapped(wpAdUnitPath)).to.be.true;
+        expect(frequencyCapping.isAdUnitCapped(wpSlot)).to.be.true;
 
         frequencyCapping.afterRequestAds();
-        expect(frequencyCapping.isAdUnitCapped(wpAdUnitPath)).to.be.false;
+        expect(frequencyCapping.isAdUnitCapped(wpSlot)).to.be.false;
       });
 
       it('should use impressionViewable events for pacing by request ads if the format is interstitial', () => {
         const frequencyCapping = makeFrequencyCapping([
           {
-            adUnitPath: interstitialDomId,
+            adUnitPath: interstitialAdUnitPath,
             conditions: { pacingRequestAds: { requestAds: 2 } }
           }
         ]);
         const format = googletag.enums.OutOfPageFormat.INTERSTITIAL.toString();
+        interstitalSlot.setTargeting(formatKey, format);
 
-        expect(frequencyCapping.isAdUnitCapped(interstitialDomId)).to.be.false;
+        expect(frequencyCapping.isAdUnitCapped(interstitalSlot)).to.be.false;
 
         // this has no effect
-        frequencyCapping.onSlotRenderEnded(slotRenderEndedEvent(false, interstitialDomId, format));
+        frequencyCapping.onSlotRenderEnded(slotRenderEndedEvent(false, interstitalSlot));
         frequencyCapping.afterRequestAds();
-        expect(frequencyCapping.isAdUnitCapped(interstitialDomId)).to.be.false;
+        expect(frequencyCapping.isAdUnitCapped(interstitalSlot)).to.be.false;
 
         // this should cap the ad unit
-        frequencyCapping.onImpressionViewable(impressionViewableEvent(interstitialDomId, format));
-        expect(frequencyCapping.isAdUnitCapped(interstitialDomId)).to.be.true;
+        frequencyCapping.onImpressionViewable(impressionViewableEvent(interstitalSlot));
+        expect(frequencyCapping.isAdUnitCapped(interstitalSlot)).to.be.true;
 
         frequencyCapping.afterRequestAds();
         frequencyCapping.afterRequestAds();
-        expect(frequencyCapping.isAdUnitCapped(interstitialDomId)).to.be.false;
+        expect(frequencyCapping.isAdUnitCapped(interstitalSlot)).to.be.false;
       });
     });
 
@@ -344,20 +358,22 @@ describe('FrequencyCapping', () => {
           }
         ]);
 
-        expect(frequencyCapping.isAdUnitCapped(wpAdUnitPath)).to.be.false;
-        frequencyCapping.onSlotRenderEnded(slotRenderEndedEvent(false, wpAdUnitPath));
-        expect(frequencyCapping.isAdUnitCapped(wpAdUnitPath)).to.be.false;
-        frequencyCapping.onSlotRenderEnded(slotRenderEndedEvent(false, wpAdUnitPath));
-        expect(frequencyCapping.isAdUnitCapped(wpAdUnitPath)).to.be.true;
+        expect(frequencyCapping.isAdUnitCapped(wpSlot)).to.be.false;
+        frequencyCapping.onSlotRenderEnded(slotRenderEndedEvent(false, wpSlot));
+        expect(frequencyCapping.isAdUnitCapped(wpSlot)).to.be.false;
+        frequencyCapping.onSlotRenderEnded(slotRenderEndedEvent(false, wpSlot));
+        expect(frequencyCapping.isAdUnitCapped(wpSlot)).to.be.true;
 
         sandbox.clock.tick(30100);
-        expect(frequencyCapping.isAdUnitCapped(wpAdUnitPath)).to.be.false;
+        expect(frequencyCapping.isAdUnitCapped(wpSlot)).to.be.false;
       });
 
       it('should update the configs when the ad unit path variables are updated', () => {
         nowInstantStub.returns(100000);
         const adUnitPathWithVars = '/123,456/example/{device}';
+        const woSlotWithUnresolvedPath = googleAdSlotStub(adUnitPathWithVars, wpDomId);
         const adUnitPathWithVarsResolved = '/123,456/example/mobile';
+        const wpSlotWithResolvedPath = googleAdSlotStub(adUnitPathWithVarsResolved, wpDomId);
         const frequencyCapping = makeFrequencyCapping([
           {
             adUnitPath: adUnitPathWithVars,
@@ -366,39 +382,40 @@ describe('FrequencyCapping', () => {
         ]);
 
         frequencyCapping.updateAdUnitPaths({ device: 'mobile' });
-        expect(frequencyCapping.isAdUnitCapped(adUnitPathWithVarsResolved)).to.be.false;
-        frequencyCapping.onSlotRenderEnded(slotRenderEndedEvent(false, adUnitPathWithVarsResolved));
+        expect(frequencyCapping.isAdUnitCapped(wpSlotWithResolvedPath)).to.be.false;
+        frequencyCapping.onSlotRenderEnded(slotRenderEndedEvent(false, wpSlotWithResolvedPath));
 
-        expect(frequencyCapping.isAdUnitCapped(wpAdUnitPath)).to.be.false;
-        frequencyCapping.onSlotRenderEnded(slotRenderEndedEvent(false, adUnitPathWithVarsResolved));
-        expect(frequencyCapping.isAdUnitCapped(adUnitPathWithVarsResolved)).to.be.true;
+        expect(frequencyCapping.isAdUnitCapped(woSlotWithUnresolvedPath)).to.be.false;
+        frequencyCapping.onSlotRenderEnded(slotRenderEndedEvent(false, wpSlotWithResolvedPath));
+        expect(frequencyCapping.isAdUnitCapped(wpSlotWithResolvedPath)).to.be.true;
 
         sandbox.clock.tick(30100);
-        expect(frequencyCapping.isAdUnitCapped(adUnitPathWithVarsResolved)).to.be.false;
+        expect(frequencyCapping.isAdUnitCapped(wpSlotWithResolvedPath)).to.be.false;
       });
 
       it('should use impressionViewable events for pacing by interval if the format is interstitial', () => {
         nowInstantStub.returns(100000);
         const frequencyCapping = makeFrequencyCapping([
           {
-            adUnitPath: interstitialDomId,
+            adUnitPath: interstitialAdUnitPath,
             conditions: { pacingInterval: { intervalInMs: 30000, maxImpressions: 1 } }
           }
         ]);
         const format = googletag.enums.OutOfPageFormat.INTERSTITIAL.toString();
+        interstitalSlot.setTargeting(formatKey, format);
 
-        expect(frequencyCapping.isAdUnitCapped(interstitialDomId)).to.be.false;
+        expect(frequencyCapping.isAdUnitCapped(interstitalSlot)).to.be.false;
 
         // this has no effect
-        frequencyCapping.onSlotRenderEnded(slotRenderEndedEvent(false, interstitialDomId, format));
-        expect(frequencyCapping.isAdUnitCapped(interstitialDomId)).to.be.false;
+        frequencyCapping.onSlotRenderEnded(slotRenderEndedEvent(false, interstitalSlot));
+        expect(frequencyCapping.isAdUnitCapped(interstitalSlot)).to.be.false;
 
         // this should cap the ad unit
-        frequencyCapping.onImpressionViewable(impressionViewableEvent(interstitialDomId, format));
-        expect(frequencyCapping.isAdUnitCapped(interstitialDomId)).to.be.true;
+        frequencyCapping.onImpressionViewable(impressionViewableEvent(interstitalSlot));
+        expect(frequencyCapping.isAdUnitCapped(interstitalSlot)).to.be.true;
 
         sandbox.clock.tick(30100);
-        expect(frequencyCapping.isAdUnitCapped(interstitialDomId)).to.be.false;
+        expect(frequencyCapping.isAdUnitCapped(interstitalSlot)).to.be.false;
       });
     });
 
@@ -411,7 +428,7 @@ describe('FrequencyCapping', () => {
           { adUnitPath: wpAdUnitPath, conditions: { adRequestLimit: { maxAdRequests: 1 } } }
         ]);
 
-        expect(frequencyCapping.isAdUnitCapped(wpAdUnitPath)).to.be.false;
+        expect(frequencyCapping.isAdUnitCapped(wpSlot)).to.be.false;
       });
 
       it('should cap if the number of ad requests exceeds the configured limit', () => {
@@ -419,7 +436,7 @@ describe('FrequencyCapping', () => {
           { adUnitPath: wpAdUnitPath, conditions: { adRequestLimit: { maxAdRequests: 1 } } }
         ]);
         frequencyCapping.onSlotRequested(slotRequestedEvent);
-        expect(frequencyCapping.isAdUnitCapped(wpAdUnitPath)).to.be.true;
+        expect(frequencyCapping.isAdUnitCapped(wpSlot)).to.be.true;
       });
 
       it('should reset the cap for the next request ads cycle', () => {
@@ -427,9 +444,9 @@ describe('FrequencyCapping', () => {
           { adUnitPath: wpAdUnitPath, conditions: { adRequestLimit: { maxAdRequests: 1 } } }
         ]);
         frequencyCapping.onSlotRequested(slotRequestedEvent);
-        expect(frequencyCapping.isAdUnitCapped(wpAdUnitPath)).to.be.true;
+        expect(frequencyCapping.isAdUnitCapped(wpSlot)).to.be.true;
         frequencyCapping.beforeRequestAds();
-        expect(frequencyCapping.isAdUnitCapped(wpAdUnitPath)).to.be.false;
+        expect(frequencyCapping.isAdUnitCapped(wpSlot)).to.be.false;
       });
     });
 
@@ -439,13 +456,13 @@ describe('FrequencyCapping', () => {
           { adUnitPath: wpDomId, conditions: { delay: { minRequestAds: 1 } } }
         ]);
 
-        expect(frequencyCapping.isFrequencyCapped('another-slot', prebidjs.DSPX)).to.be.false;
+        expect(frequencyCapping.isBidderCapped('another-slot', prebidjs.DSPX)).to.be.false;
       });
 
       it('should not cap if no conditions are set', () => {
         const frequencyCapping = makeFrequencyCapping([{ adUnitPath: wpDomId, conditions: {} }]);
 
-        expect(frequencyCapping.isFrequencyCapped(wpDomId, prebidjs.DSPX)).to.be.false;
+        expect(frequencyCapping.isBidderCapped(wpDomId, prebidjs.DSPX)).to.be.false;
       });
 
       it('should not cap if all conditions are met', () => {
@@ -460,10 +477,10 @@ describe('FrequencyCapping', () => {
           }
         ]);
 
-        expect(frequencyCapping.isAdUnitCapped(wpAdUnitPath)).to.be.true;
+        expect(frequencyCapping.isAdUnitCapped(wpSlot)).to.be.true;
         frequencyCapping.afterRequestAds();
         frequencyCapping.afterRequestAds();
-        expect(frequencyCapping.isAdUnitCapped(wpAdUnitPath)).to.be.false;
+        expect(frequencyCapping.isAdUnitCapped(wpSlot)).to.be.false;
       });
     });
   });
@@ -476,7 +493,7 @@ describe('FrequencyCapping', () => {
         nowInstantStub,
         noopLogger
       );
-      expect(frequencyCapping.isFrequencyCapped('wp-slot', prebidjs.DSPX)).to.be.false;
+      expect(frequencyCapping.isBidderCapped('wp-slot', prebidjs.DSPX)).to.be.false;
     });
 
     it('should not add a frequency cap if the stored data is invalid', () => {
@@ -489,7 +506,7 @@ describe('FrequencyCapping', () => {
         nowInstantStub,
         logger
       );
-      expect(frequencyCapping.isFrequencyCapped('wp-slot', prebidjs.DSPX)).to.be.false;
+      expect(frequencyCapping.isBidderCapped('wp-slot', prebidjs.DSPX)).to.be.false;
       expect(errorSpy).to.have.been.called;
     });
 
@@ -513,7 +530,7 @@ describe('FrequencyCapping', () => {
         nowInstantStub,
         noopLogger
       );
-      expect(frequencyCapping.isFrequencyCapped(wpDomId, prebidjs.DSPX)).to.be.true;
+      expect(frequencyCapping.isBidderCapped(wpDomId, prebidjs.DSPX)).to.be.true;
       expect(setTimeoutSpy).to.have.been.calledOnceWithExactly(
         Sinon.match.func,
         waitTime - timePassed
@@ -550,7 +567,7 @@ describe('FrequencyCapping', () => {
         nowInstantStub,
         noopLogger
       );
-      expect(frequencyCapping.isAdUnitCapped(wpAdUnitPath)).to.be.true;
+      expect(frequencyCapping.isAdUnitCapped(wpSlot)).to.be.true;
       expect(setTimeoutSpy).to.have.been.calledOnceWithExactly(
         Sinon.match.func,
         waitTime - timePassed
@@ -579,7 +596,7 @@ describe('FrequencyCapping', () => {
         wait: visxInterstitialConfig.conditions.pacingInterval?.intervalInMs
       });
 
-      expect(frequencyCapping.isFrequencyCapped(interstitialDomId, prebidjs.Visx)).to.be.true;
+      expect(frequencyCapping.isBidderCapped(interstitialDomId, prebidjs.Visx)).to.be.true;
     });
 
     it('should persist onBidWon events', () => {
@@ -602,7 +619,7 @@ describe('FrequencyCapping', () => {
         wait: dspxWpConfig.conditions.pacingInterval?.intervalInMs
       });
 
-      expect(frequencyCapping.isFrequencyCapped(wpDomId, prebidjs.DSPX)).to.be.true;
+      expect(frequencyCapping.isBidderCapped(wpDomId, prebidjs.DSPX)).to.be.true;
     });
 
     it('should persist on afterRequestAds events', () => {
@@ -638,7 +655,7 @@ describe('FrequencyCapping', () => {
         nowInstantStub,
         noopLogger
       );
-      frequencyCapping.onSlotRenderEnded(slotRenderEndedEvent(false, wpAdUnitPath));
+      frequencyCapping.onSlotRenderEnded(slotRenderEndedEvent(false, wpSlot));
       const storedData = jsDomWindow.sessionStorage.getItem('h5v-fc');
       expect(storedData).to.be.ok;
       const persistedState = JSON.parse(storedData!);
@@ -649,7 +666,7 @@ describe('FrequencyCapping', () => {
         wait: 10000
       });
 
-      expect(frequencyCapping.isAdUnitCapped(wpAdUnitPath)).to.be.true;
+      expect(frequencyCapping.isAdUnitCapped(wpSlot)).to.be.true;
     });
 
     it('should persist number of ad requests for ad unit path if slot was rendered', () => {
@@ -670,7 +687,7 @@ describe('FrequencyCapping', () => {
         noopLogger
       );
       frequencyCapping.afterRequestAds();
-      frequencyCapping.onSlotRenderEnded(slotRenderEndedEvent(false, wpAdUnitPath));
+      frequencyCapping.onSlotRenderEnded(slotRenderEndedEvent(false, wpSlot));
       const storedData = jsDomWindow.sessionStorage.getItem('h5v-fc');
       expect(storedData).to.be.ok;
       const persistedState = JSON.parse(storedData!);
@@ -715,8 +732,8 @@ describe('FrequencyCapping', () => {
         wait: visxInterstitialConfig.conditions.pacingInterval?.intervalInMs
       });
 
-      expect(frequencyCapping.isFrequencyCapped(interstitialDomId, prebidjs.Visx)).to.be.true;
-      expect(frequencyCapping.isFrequencyCapped(interstitialDomId, prebidjs.GumGum)).to.be.true;
+      expect(frequencyCapping.isBidderCapped(interstitialDomId, prebidjs.Visx)).to.be.true;
+      expect(frequencyCapping.isBidderCapped(interstitialDomId, prebidjs.GumGum)).to.be.true;
     });
   });
 });

--- a/ad-tag/source/ts/ads/globalAuctionContext.test.ts
+++ b/ad-tag/source/ts/ads/globalAuctionContext.test.ts
@@ -3,7 +3,7 @@ import { expect, use } from 'chai';
 import { createDomAndWindow } from '../stubs/browserEnvSetup';
 import { createGlobalAuctionContext, GlobalAuctionContext } from './globalAuctionContext';
 import { createPbjsStub } from '../stubs/prebidjsStubs';
-import { createGoogletagStub } from '../stubs/googletagStubs';
+import { createGoogletagStub, googleAdSlotStub } from '../stubs/googletagStubs';
 import sinonChai from 'sinon-chai';
 import { noopLogger } from 'ad-tag/stubs/moliStubs';
 import { createEventService } from './eventService';
@@ -141,7 +141,7 @@ describe('Global auction context', () => {
 
       it('should never throttle requests in initial state', () => {
         const context = makeAuctionContext(auctionContextConfig);
-        expect(context.isSlotThrottled('slot-1', '/123/slot-1')).to.be.false;
+        expect(context.isSlotThrottled(googleAdSlotStub('/123/slot-1', 'slot-1'))).to.be.false;
       });
 
       it('should add slotRequested event listener', () => {
@@ -164,7 +164,7 @@ describe('Global auction context', () => {
 
       it('should never throttle requests', () => {
         const context = makeAuctionContext(auctionContextConfig);
-        expect(context.isSlotThrottled('slot-1', '/123/slot-1')).to.be.false;
+        expect(context.isSlotThrottled(googleAdSlotStub('/123/slot-1', 'slot-1'))).to.be.false;
       });
 
       it('should not add slotRequested event listener if disabled', () => {

--- a/ad-tag/source/ts/ads/globalAuctionContext.ts
+++ b/ad-tag/source/ts/ads/globalAuctionContext.ts
@@ -4,7 +4,7 @@ import { createBiddersDisabling } from './auctions/biddersDisabling';
 import { createAdRequestThrottling } from './auctions/adRequestThrottling';
 import { auction } from '../types/moliConfig';
 import { createFrequencyCapping } from './auctions/frequencyCapping';
-import { createPreviousBidCpms, PreviousBidCpms } from './auctions/previousBidCpms';
+import { createPreviousBidCpms } from './auctions/previousBidCpms';
 import { MoliRuntime } from 'ad-tag/types/moliRuntime';
 import { EventService } from './eventService';
 import { ConfigureStep, mkConfigureStep } from './adPipeline';
@@ -26,7 +26,11 @@ import { createInterstitialContext } from 'ad-tag/ads/auctions/interstitialConte
  * Every new feature must be enabled separately and should not share any data with other features.
  */
 export interface GlobalAuctionContext {
-  isSlotThrottled(slotId: string, adUnitPath: string): boolean;
+  /**
+   *
+   * @param slot The GPT ad slot to check
+   */
+  isSlotThrottled(slot: googletag.IAdSlot): boolean;
   isBidderFrequencyCappedOnSlot(slotId: string, bidder: string): boolean;
   getLastBidCpmsOfAdUnit(slotId: string): number[];
 
@@ -134,13 +138,14 @@ export const createGlobalAuctionContext = (
   });
 
   return {
-    isSlotThrottled(slotId: string, adUnitPath: string): boolean {
+    isSlotThrottled(slot: googletag.IAdSlot): boolean {
       return !!(
-        adRequestThrottling?.isThrottled(slotId) || frequencyCapping?.isAdUnitCapped(adUnitPath)
+        adRequestThrottling?.isThrottled(slot.getSlotElementId()) ||
+        frequencyCapping?.isAdUnitCapped(slot)
       );
     },
     isBidderFrequencyCappedOnSlot(slotId: string, bidder: prebidjs.BidderCode): boolean {
-      return frequencyCapping?.isFrequencyCapped(slotId, bidder) ?? false;
+      return frequencyCapping?.isBidderCapped(slotId, bidder) ?? false;
     },
     getLastBidCpmsOfAdUnit(slotId: string): number[] {
       return previousBidCpms?.getLastBidCpms(slotId) ?? [];

--- a/ad-tag/source/ts/ads/googleAdManager.test.ts
+++ b/ad-tag/source/ts/ads/googleAdManager.test.ts
@@ -1007,8 +1007,8 @@ describe('google ad manager', () => {
         } as MoliRuntime.SlotDefinition;
 
         const isThrottledStub = sandbox.stub(ctx.auction__, 'isSlotThrottled');
-        isThrottledStub.withArgs(slot1.moliSlot.domId, slot1.adSlot.getAdUnitPath()).returns(true);
-        isThrottledStub.withArgs(slot2.moliSlot.domId, slot2.adSlot.getAdUnitPath()).returns(false);
+        isThrottledStub.withArgs(slot1.adSlot).returns(true);
+        isThrottledStub.withArgs(slot2.adSlot).returns(false);
 
         await step(ctx, [slot1, slot2]);
         expect(isThrottledStub).to.have.been.calledTwice;

--- a/ad-tag/source/ts/ads/googleAdManager.ts
+++ b/ad-tag/source/ts/ads/googleAdManager.ts
@@ -575,8 +575,7 @@ export const gptRequestAds =
           break;
         case 'production':
           const slotsToRefresh = slots.filter(
-            ({ moliSlot, adSlot }) =>
-              !context.auction__.isSlotThrottled(moliSlot.domId, adSlot.getAdUnitPath())
+            ({ adSlot }) => !context.auction__.isSlotThrottled(adSlot)
           );
           if (slotsToRefresh.length === 0) {
             break;

--- a/ad-tag/source/ts/ads/prebid.test.ts
+++ b/ad-tag/source/ts/ads/prebid.test.ts
@@ -1140,14 +1140,15 @@ describe('prebid', () => {
       const requestBidsSpy = sandbox.spy(dom.window.pbjs, 'requestBids');
       const step = prebidRequestBids(moliPrebidTestConfig, 'gam');
       const slot = createAdSlot('none-prebid');
+      const googleAdSlot = googleAdSlotStub(slot.adUnitPath, slot.domId);
       const ctx = adPipelineContext();
       const isThrottledStub = sandbox.stub(ctx.auction__, 'isSlotThrottled');
-      isThrottledStub.withArgs(slot.domId, slot.adUnitPath).returns(true);
+      isThrottledStub.withArgs(googleAdSlot).returns(true);
 
       await step(ctx, [
         {
           moliSlot: slot,
-          adSlot: googleAdSlotStub(slot.adUnitPath, slot.domId),
+          adSlot: googleAdSlot,
           filterSupportedSizes: sizes => sizes
         }
       ]);
@@ -1179,8 +1180,8 @@ describe('prebid', () => {
 
       const ctx = adPipelineContext();
       const isThrottledStub = sandbox.stub(ctx.auction__, 'isSlotThrottled');
-      isThrottledStub.withArgs(domId1, slotDef1.adSlot.getAdUnitPath()).returns(false);
-      isThrottledStub.withArgs(domId2, slotDef2.adSlot.getAdUnitPath()).returns(true);
+      isThrottledStub.withArgs(slotDef1.adSlot).returns(false);
+      isThrottledStub.withArgs(slotDef2.adSlot).returns(true);
 
       await step(ctx, [slotDef1, slotDef2]);
       expect(requestBidsSpy).to.have.been.calledOnce;
@@ -1271,9 +1272,9 @@ describe('prebid', () => {
       const ctx = adPipelineContext();
       sandbox
         .stub(ctx.auction__, 'isSlotThrottled')
-        .withArgs(domId1, slotDef1.adSlot.getAdUnitPath())
+        .withArgs(slotDef1.adSlot)
         .returns(false)
-        .withArgs(domId2, slotDef2.adSlot.getAdUnitPath())
+        .withArgs(slotDef2.adSlot)
         .returns(true);
 
       await step(ctx, [slotDef1, slotDef2]);

--- a/ad-tag/source/ts/ads/prebid.ts
+++ b/ad-tag/source/ts/ads/prebid.ts
@@ -356,6 +356,7 @@ export const prebidConfigure = (
             });
           }
 
+          // TODO is is where additional HEM configuration would be added for id5 from the runtimeConfig.audience
           context.window__.pbjs.setConfig({
             ...prebidConfig.config,
             // global schain configuration
@@ -364,6 +365,7 @@ export const prebidConfigure = (
             ...{ floors: prebidConfig.config.floors || {} }
           });
 
+          // TODO bidder specific HEM configuration, e.g. for Criteo, would be done here.
           // set additional bidder configurations if provided
           prebidConfig.bidderConfigs?.forEach(({ options, merge }) => {
             context.window__.pbjs.setBidderConfig(options, merge);
@@ -455,7 +457,7 @@ export const prebidRequestBids = (
         const slotsToRefresh = slots.filter(
           slot =>
             // keep slots that are not throttled
-            !context.auction__.isSlotThrottled(slot.moliSlot.domId, slot.adSlot.getAdUnitPath()) &&
+            !context.auction__.isSlotThrottled(slot.adSlot) &&
             // keep slots that are not and interstitial or interstitials that are not from GAM web interstitials
             (!isGamInterstitial(slot.adSlot, context.window__) ||
               context.auction__.interstitialChannel() !== 'gam')


### PR DESCRIPTION
The google web interstitial behaves differently than the "custom" interstitial implementation.
While the google web interstitial has certain triggers, most importantly the navigation trigger, the custom implementation is always rendered.

Hence we adjust the `delay.minRequestAds` if the format in question is a GAM interstitial. The limit is reduce by one.