### PR TITLE
Move all previous key values to GAM interstitial during switch

### DIFF
--- a/ad-tag/source/ts/ads/googleAdManager.test.ts
+++ b/ad-tag/source/ts/ads/googleAdManager.test.ts
@@ -333,11 +333,12 @@ describe('google ad manager', () => {
           }
         }
       };
-      const clearTargetingSpy = sandbox.spy(dom.window.googletag.pubads(), 'clearTargeting');
+      const setConfigSpy = sandbox.spy(dom.window.googletag, 'setConfig');
       const setTargetingSpy = sandbox.spy(dom.window.googletag.pubads(), 'setTargeting');
       await step(adPipelineContext('production', configWithTargeting), []);
-      Sinon.assert.callOrder(clearTargetingSpy, setTargetingSpy);
-      expect(clearTargetingSpy).to.have.been.calledOnce;
+      Sinon.assert.callOrder(setConfigSpy, setTargetingSpy);
+      expect(setConfigSpy).to.have.been.calledOnce;
+      expect(setConfigSpy).calledWith({ targeting: null });
       expect(setTargetingSpy).to.have.been.calledTwice;
       expect(setTargetingSpy).to.have.been.calledWith('foo', 'bar');
       expect(setTargetingSpy).to.have.been.calledWith('tags', ['car', 'truck']);
@@ -345,14 +346,15 @@ describe('google ad manager', () => {
 
     it('should only be executed once per requestAds cycle', async () => {
       const step = gptResetTargeting();
-      const clearTargetingSpy = sandbox.spy(dom.window.googletag.pubads(), 'clearTargeting');
+      const setConfigSpy = sandbox.spy(dom.window.googletag, 'setConfig');
       await Promise.all([
         step(adPipelineContext('production', emptyConfig, 1), []),
         step(adPipelineContext('production', emptyConfig, 1), []),
         step(adPipelineContext('production', emptyConfig, 2), []),
         step(adPipelineContext('production', emptyConfig, 2), [])
       ]);
-      expect(clearTargetingSpy).to.have.been.calledTwice;
+      expect(setConfigSpy).to.have.been.calledTwice;
+      expect(setConfigSpy).calledWith({ targeting: null });
     });
   });
 
@@ -1079,9 +1081,9 @@ describe('google ad manager', () => {
           expect(interstitialChannelStub).to.have.been.calledOnce;
           expect(destroySlotsSpy).to.have.been.calledOnce;
           expect(destroySlotsSpy).to.have.been.calledOnceWithExactly([slot.adSlot]);
-          expect(newSlot.getTargeting(formatKey)).to.deep.eq([
+          expect(newSlot.getConfig('targeting')![formatKey]).to.deep.eq(
             jsDomWindow.googletag.enums.OutOfPageFormat.INTERSTITIAL.toString()
-          ]);
+          );
         });
       });
     });

--- a/ad-tag/source/ts/ads/googleAdManager.ts
+++ b/ad-tag/source/ts/ads/googleAdManager.ts
@@ -64,6 +64,9 @@ const testAdSlot = (domId: string, adUnitPath: string): googletag.IAdSlot => ({
 
   setConfig(_config: googletag.GptSlotSettingsConfig) {
     return;
+  },
+  getConfig(_key): any {
+    return;
   }
 });
 
@@ -76,6 +79,7 @@ const configureTargeting = (
   const excludes = serverSideTargeting?.adManagerExcludes ?? [];
 
   // first use the static targeting and override if necessary with the runtime key values
+  // TODO use googletag.setConfig(targeting) instead as setTargeting is deprecated
   [staticKeyValues, runtimeKeyValues].forEach(keyValues => {
     Object.keys(keyValues)
       .filter(key => !excludes.includes(key))
@@ -221,7 +225,7 @@ export const gptResetTargeting = (): ConfigureStep =>
       new Promise<void>(resolve => {
         if (context.env__ === 'production') {
           context.logger__.debug('GAM', 'reset top level targeting');
-          context.window__.googletag.pubads().clearTargeting();
+          context.window__.googletag.setConfig({ targeting: null });
           configureTargeting(
             context.window__,
             context.runtimeConfig__.keyValues,
@@ -534,6 +538,7 @@ const checkAndSwitchToWebInterstitial = (
   );
 
   if (interstitialSlot && context.auction__.interstitialChannel() === 'gam') {
+    const targeting = { ...interstitialSlot.adSlot.getConfig('targeting') };
     // if there are no bids, we switch to the out-of-page-interstitial position
     context.window__.googletag.destroySlots([interstitialSlot.adSlot]);
 
@@ -546,10 +551,12 @@ const checkAndSwitchToWebInterstitial = (
 
       // this little dance is annoying - refresh is done afterwards
       gamWebInterstitial.addService(context.window__.googletag.pubads());
-      gamWebInterstitial.setTargeting(
-        formatKey,
-        context.window__.googletag.enums.OutOfPageFormat.INTERSTITIAL.toString()
-      );
+      gamWebInterstitial.setConfig({
+        targeting: {
+          ...targeting,
+          [formatKey]: context.window__.googletag.enums.OutOfPageFormat.INTERSTITIAL.toString()
+        }
+      });
       context.window__.googletag.display(gamWebInterstitial);
 
       // early return to swap the interstitial slot

--- a/ad-tag/source/ts/stubs/googletagStubs.ts
+++ b/ad-tag/source/ts/stubs/googletagStubs.ts
@@ -1,4 +1,6 @@
 import { googletag } from '../types/googletag';
+import GptPageSettingsConfig = googletag.GptPageSettingsConfig;
+import GptSlotSettingsConfig = googletag.GptSlotSettingsConfig;
 
 const createPubAdsServiceStub = (): googletag.IPubAdsService => {
   const stub = {
@@ -50,6 +52,7 @@ const createPubAdsServiceStub = (): googletag.IPubAdsService => {
 };
 
 export const googleAdSlotStub = (adUnitPath: string, slotId: string): googletag.IAdSlot => {
+  let config: GptSlotSettingsConfig = {};
   let targetingMap: Record<string, string[]> = {};
   const stub: googletag.IAdSlot = {
     clearTargeting(key?: string): void {
@@ -89,8 +92,11 @@ export const googleAdSlotStub = (adUnitPath: string, slotId: string): googletag.
     getResponseInformation: (): googletag.IResponseInformation | null => {
       return null;
     },
-    setConfig(_config: googletag.GptSlotSettingsConfig) {
-      return;
+    setConfig(additionalConfig: googletag.GptSlotSettingsConfig) {
+      config = { ...config, ...additionalConfig };
+    },
+    getConfig(key) {
+      return config[key];
     }
   };
   return stub;
@@ -98,6 +104,7 @@ export const googleAdSlotStub = (adUnitPath: string, slotId: string): googletag.
 
 export const createGoogletagStub = (): googletag.IGoogleTag => {
   const pubAdsStub = createPubAdsServiceStub();
+  let pageConfig: GptPageSettingsConfig = {};
 
   return {
     pubadsReady: true,
@@ -135,8 +142,12 @@ export const createGoogletagStub = (): googletag.IGoogleTag => {
       return;
     },
     pubads: (): googletag.IPubAdsService => pubAdsStub,
-    setConfig: (): void => {
+    setConfig: (additionalConfig): void => {
+      pageConfig = { ...pageConfig, ...additionalConfig };
       return;
+    },
+    getConfig(key) {
+      return pageConfig[key];
     },
     secureSignalProviders: {
       push(provider: { id: string; collectorFunction(): any }) {

--- a/ad-tag/source/ts/types/googletag.ts
+++ b/ad-tag/source/ts/types/googletag.ts
@@ -1,4 +1,6 @@
 // type definitions for DFP googletag
+import { MoliRuntime } from 'ad-tag/types/moliRuntime';
+
 export namespace googletag {
   /**
    * Add googletag to global window instance
@@ -443,6 +445,14 @@ export namespace googletag {
      */
     setConfig(config: GptPageSettingsConfig): void;
 
+    /**
+     * Gets general configuration options for the page set by setConfig.
+     *
+     * @param key supported config keys
+     * @see https://developers.google.com/publisher-tag/reference#googletag.getConfig
+     */
+    getConfig: <T extends keyof GetPageSettingsConfigKey>(key: T) => GptPageSettingsConfig[T];
+
     secureSignalProviders: {
       push(provider: { id: string; collectorFunction(): any }): void;
 
@@ -455,10 +465,114 @@ export namespace googletag {
      * Settings to control/override ad expansion behavior.
      */
     readonly adExpansion?: { enabled: boolean };
+
+    /**
+     * Setting to control when ads are requested.
+     *
+     * By default, the googletag.display method both registers ad slots and requests ads for them.
+     * However, there are times when it may be preferable to separate these actions, in order to more
+     * precisely control when ad content is loaded.
+     *
+     * By enabling this setting, ads will not be requested for registered slots when the display() method is called. Instead, a separate call to PubAdsService.refresh must be made to initiate an ad request.
+     * This method must be called before calling googletag.enableServices.
+     *
+     * @see https://developers.google.com/publisher-tag/reference#googletag.config.PageSettingsConfig.disableInitialLoad
+     */
+    readonly disableInitialLoad?: boolean;
+
+    /**
+     * Settings to control the use of lazy loading in GPT.
+     *
+     * Lazy loading is a technique to delay the requesting and rendering of ads until they approach the user's viewport.
+     * For a more detailed example, see the Lazy loading sample.
+     *
+     * Note: If singleRequest is enabled, lazy fetching only works when all slots are outside the fetch margin.
+     *
+     * Any lazy load settings which are not specified when calling setConfig() will use a default value set by Google.
+     * These defaults may be tuned over time. To disable a particular setting, set the value to null.
+     *
+     * @see https://developers.google.com/publisher-tag/reference#googletag.config.PageSettingsConfig.lazyLoad
+     * @see https://developers.google.com/publisher-tag/reference#googletag.config.LazyLoadConfig
+     */
+    readonly lazyLoad?: {
+      /**
+       * The minimum distance from the current viewport a slot must be before we request an ad, expressed as a percentage
+       * of viewport size.
+       *
+       * Used in conjunction with renderMarginPercent, this setting allows for prefetching an ad, but waiting to render
+       * and download other subresources. As such, this value should always be greater than or equal to renderMarginPercent.
+       *
+       * A value of 0 means "when the slot enters the viewport", 100 means "when the ad is 1 viewport away", and so on.
+       */
+      fetchMarginPercent?: number;
+
+      /**
+       * The minimum distance from the current viewport a slot must be before we render an ad, expressed as a percentage
+       * of viewport size.
+       *
+       * Used in conjunction with fetchMarginPercent, this setting allows for prefetching an ad, but waiting to render
+       * and download other subresources. As such, this value should always be less than or equal to fetchMarginPercent.
+       *
+       * A value of 0 means "when the slot enters the viewport", 100 means "when the ad is 1 viewport away", and so on.
+       */
+      renderMarginPercent?: number;
+
+      /**
+       * A multiplier applied to margins on mobile devices. This multiplier is applied to both fetchMarginPercent and renderMarginPercent.
+       *
+       * This allows for different margins on mobile vs. desktop, where viewport sizes and scroll speeds may be different.
+       * For example, a value of 2.0 will multiply all margins by 2 on mobile devices, increasing the minimum distance a
+       * slot can be from the viewport before fetching and rendering.
+       */
+      mobileScaling?: number;
+    };
     /**
      * Settings to control publisher privacy treatments.
      */
     readonly privacyTreatments?: { treatments: 'disablePersonalization'[] };
+
+    /**
+     * Setting to control the horizontal centering of ads. Centering is disabled by default.
+     *
+     * Horizontal centering changes only apply to ads requested after this method has been called.
+     * For that reason, it is recommended to call this method before any calls to googletag.display
+     * or PubAdsService.refresh.
+     *
+     * @see https://developers.google.com/publisher-tag/reference#googletag.config.PageSettingsConfig.centering
+     */
+    readonly centering?: boolean;
+
+    /**
+     * Setting to control key-value targeting.
+     *
+     * Targeting configured via this setting will apply to all ad slots on the page. This setting may be called multiple
+     * times to define multiple targeting key-values, or overwrite existing values. Targeting keys are defined in your
+     * Google Ad Manager account.
+     *
+     * @see https://developers.google.com/publisher-tag/reference#googletag.config.PageSettingsConfig.targeting
+     */
+    readonly targeting?: Record<string, string | string[]> | null;
+
+    /**
+     * Setting to geo-target line items to geographic locations.
+     * @see https://developers.google.com/publisher-tag/reference#googletag.config.PageSettingsConfig.location
+     */
+    readonly location?: string;
+
+    /**
+     * Setting to enable or disable Single Request Architecture (SRA).
+     *
+     * When SRA is enabled, all ad slots defined prior to a googletag.display or PubAdsService.refresh call will be
+     * batched into a single ad request. This provides performance benefits, but is also necessary to ensure roadblocks
+     * and competetive exclusions are honored.
+     * When SRA is disabled, each ad slot is requested individually. This is the default behavior of GPT.
+     *
+     * This method must be called prior to calling googletag.enableServices.
+     *
+     * @see https://developers.google.com/publisher-tag/reference#googletag.config.PageSettingsConfig.singleRequest
+     */
+    readonly singleRequest?: boolean;
+
     /**
      * Settings to control publisher provided signals.
      */
@@ -468,6 +582,19 @@ export namespace googletag {
         IAB_AUDIENCE_2_2?: { values: string[] };
       };
     };
+
+    /**
+     * Setting to configure AdSense attributes.
+     *
+     * AdSense attributes configured via this setting will apply to all ad slots on the page. This setting may be called
+     * multiple times to define multiple attribute values, or overwrite existing values.
+     *
+     * AdSense attribute changes only apply to ads requested after this method has been called. For that reason, it is
+     * recommended to call this method before any calls to googletag.display or PubAdsService.refresh.
+     *
+     * @see https://developers.google.com/publisher-tag/reference#googletag.config.PageSettingsConfig.adsenseAttributes
+     */
+    readonly adsenseAttributes?: GptAdSenseAttributesConfig | null;
   };
 
   export interface GptAdSenseAttributesConfig {
@@ -624,7 +751,7 @@ export namespace googletag {
      * AdSense attribute changes only apply to ads requested after this method has been called.
      * For that reason, it is recommended to call this method before any calls to googletag.display or PubAdsService.refresh.
      */
-    readonly adSenseAttributes?: GptAdSenseAttributesConfig;
+    readonly adsenseAttributes?: GptAdSenseAttributesConfig;
 
     /**
      * Setting to configure ad category exclusions.
@@ -675,6 +802,16 @@ export namespace googletag {
       INTERSTITIAL = 5
     }
   }
+
+  export type GetPageSettingsConfigKey = Pick<
+    GptPageSettingsConfig,
+    'adsenseAttributes' | 'disableInitialLoad' | 'targeting'
+  >;
+
+  export type GetSlotSettingsConfigKey = Pick<
+    GptSlotSettingsConfig,
+    'adsenseAttributes' | 'categoryExclusion' | 'targeting'
+  >;
 
   /**
    * interface for Google DFP AdSlot.
@@ -755,6 +892,14 @@ export namespace googletag {
      * @param config - Configuration object for the slot.
      */
     setConfig(config: GptSlotSettingsConfig): void;
+
+    /**
+     * Gets general configuration options for the slot set by setConfig.
+     *
+     * @param key the supported config key to retrieve
+     * @see https://developers.google.com/publisher-tag/reference#googletag.Slot.getConfig
+     */
+    getConfig: <T extends keyof GetSlotSettingsConfigKey>(key: T) => GptSlotSettingsConfig[T];
   }
 
   export interface IResponseInformation {


### PR DESCRIPTION
Using the new `setConfig` API and transport the key-values from the interstitial during checkAndSwitch