### PR TITLE
Add labelAll support for a9 / amazon tam

### DIFF
--- a/ad-tag/source/ts/ads/a9.test.ts
+++ b/ad-tag/source/ts/ads/a9.test.ts
@@ -150,11 +150,32 @@ describe('a9', () => {
       expect(assetLoaderStub).to.have.been.calledOnce;
     });
 
+    it('should not load the a9 script if a9 is disabled', async () => {
+      const step = a9Init({ ...a9ConfigStub, enabled: false }, assetLoaderService);
+      const tcData__ = fullConsent({ '793': true });
+      await step({ ...adPipelineContext(), tcData__ });
+      expect(assetLoaderStub).not.have.been.called;
+    });
+
+    it('shold not load the a9 script if labels are not matching', async () => {
+      const step = a9Init({ ...a9ConfigStub, labelAll: ['a9'] }, assetLoaderService);
+      const tcData__ = fullConsent({ '793': true });
+      const ctxWithLabelServiceStub = {
+        ...adPipelineContext('production', emptyConfig)
+      };
+      const getSupportedLabelsStub = sandbox
+        .stub(ctxWithLabelServiceStub.labelConfigService__, 'getSupportedLabels')
+        .returns(['desktop']);
+      await step({ ...ctxWithLabelServiceStub, tcData__ });
+      expect(getSupportedLabelsStub).to.have.been.calledOnce;
+      expect(assetLoaderStub).not.have.been.called;
+    });
+
     it('should not load the a9 script if vendor consent is false', async () => {
       const step = a9Init(a9ConfigStub, assetLoaderService);
-      const tcData = fullConsent({ '793': false });
+      const tcData__ = fullConsent({ '793': false });
 
-      await step({ ...adPipelineContext(), tcData__: tcData });
+      await step({ ...adPipelineContext(), tcData__ });
       expect(assetLoaderStub).not.have.been.called;
     });
 
@@ -182,6 +203,27 @@ describe('a9', () => {
         await step({ ...adPipelineContext(), tcData__: tcData });
         expect(assetLoaderStub).not.have.been.called;
       });
+    });
+
+    it('should load the a9 script with full consent', async () => {
+      const step = a9Init(a9ConfigStub, assetLoaderService);
+      const tcData__ = fullConsent({ '793': true });
+      await step({ ...adPipelineContext(), tcData__ });
+      expect(assetLoaderStub).to.have.been.calledOnce;
+    });
+
+    it('should load the a9 script if labelAll condition is matching', async () => {
+      const step = a9Init({ ...a9ConfigStub, labelAll: ['a9', 'mobile'] }, assetLoaderService);
+      const tcData__ = fullConsent({ '793': true });
+      const ctxWithLabelServiceStub = {
+        ...adPipelineContext('production', emptyConfig)
+      };
+      const getSupportedLabelsStub = sandbox
+        .stub(ctxWithLabelServiceStub.labelConfigService__, 'getSupportedLabels')
+        .returns(['a9', 'mobile', 'some-other-label']);
+      await step({ ...ctxWithLabelServiceStub, tcData__ });
+      expect(getSupportedLabelsStub).to.have.been.calledTwice;
+      expect(assetLoaderStub).to.have.been.calledOnce;
     });
   });
 

--- a/ad-tag/source/ts/ads/a9.ts
+++ b/ad-tag/source/ts/ads/a9.ts
@@ -86,7 +86,17 @@ export const a9Init = (
         };
 
         // only load a9 if consent is given for all purposes and Amazon Advertising (793)
-        if (context.env__ !== 'test' && hasRequiredConsent(context.tcData__)) {
+        const supportedByLabels =
+          !config.labelAll ||
+          config.labelAll.every(label =>
+            context.labelConfigService__.getSupportedLabels().includes(label)
+          );
+        if (
+          context.env__ !== 'test' &&
+          hasRequiredConsent(context.tcData__) &&
+          config.enabled !== false &&
+          supportedByLabels
+        ) {
           // async fetch as everything is already initialized
           assetService
             .loadScript({

--- a/ad-tag/source/ts/types/moliConfig.ts
+++ b/ad-tag/source/ts/types/moliConfig.ts
@@ -1095,6 +1095,22 @@ export namespace headerbidding {
 
   export interface A9Config {
     /**
+     * Disable Amazon TAM / A9 integration
+     * @default true
+     */
+    readonly enabled?: boolean;
+
+    /**
+     * Add conditions to disable a9 for certain pages.
+     * Note that this is a global setting and will disable a9 for all ad slots.
+     *
+     * NOTE: single page applications are not supported yet. The aps script is loaded initially.
+     *       If the first page view does not load the aps script, it will never be loaded for the
+     *       entire session.
+     */
+    readonly labelAll?: string[];
+
+    /**
      * publisher ID
      */
     readonly pubID: string;

--- a/schema.json
+++ b/schema.json
@@ -1508,9 +1508,21 @@
           "description": "If set to true the yield optimization floor price will be sent to amazon.\n\ndefault: false",
           "type": "boolean"
         },
+        "enabled": {
+          "default": true,
+          "description": "Disable Amazon TAM / A9 integration",
+          "type": "boolean"
+        },
         "floorPriceCurrency": {
           "$ref": "#/definitions/apstag.Currency",
           "description": "Configure the floor price currency. Will be mandatory once the feature is out of beta."
+        },
+        "labelAll": {
+          "description": "Add conditions to disable a9 for certain pages. Note that this is a global setting and will disable a9 for all ad slots.\n\nNOTE: single page applications are not supported yet. The aps script is loaded initially.       If the first page view does not load the aps script, it will never be loaded for the       entire session.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
         },
         "pubID": {
           "description": "publisher ID",


### PR DESCRIPTION
Amazon TAM ( former A9 ) can now be disabled through an `enabled` config property.
In addition it can be enabled conditionally through an optional `labelAll` property.

## Use case

This helps complying with Amazon ad service policies and disable Amazon TAM entirely on ineligible pages. 