### PR TITLE
Add lightweight geo detection

### DIFF
--- a/ad-tag/source/ts/ads/moli.ts
+++ b/ad-tag/source/ts/ads/moli.ts
@@ -13,6 +13,7 @@ import {
 import { packageJson } from '../gen/packageJson';
 import * as adUnitPath from './adUnitPath';
 import { extractTopPrivateDomainFromHostname } from '../util/extractTopPrivateDomainFromHostname';
+import { detectGeoFromBrowser } from '../util/detectGeoFromTimezone';
 import { createLabelConfigService } from './labelConfigService';
 import { allowRefreshAdSlot, allowRequestAds } from './spa';
 import {
@@ -327,6 +328,7 @@ export const createMoliTag = (window: Window): MoliRuntime.MoliTag => {
       case 'configured': {
         setABtestTargeting();
         addDomainLabel(state.config.domain);
+        addGeoLabels(state.config.targeting?.geo);
 
         const modules = state.modules;
         getLogger(state.runtimeConfig, window).debug(
@@ -540,6 +542,7 @@ export const createMoliTag = (window: Window): MoliRuntime.MoliTag => {
         // create new ABTest values
         setABtestTargeting();
         addDomainLabel(state.config.domain);
+        addGeoLabels(state.config.targeting?.geo);
 
         const { modules } = state;
         const afterRequestAds = state.nextRuntimeConfig.hooks.afterRequestAds;
@@ -877,6 +880,16 @@ export const createMoliTag = (window: Window): MoliRuntime.MoliTag => {
       domainFromConfig || extractTopPrivateDomainFromHostname(window.location.hostname);
     if (domain) {
       addLabel(domain);
+    }
+  }
+
+  function addGeoLabels(geoFromConfig?: googleAdManager.GeoConfig): void {
+    const { country, continent } = geoFromConfig ?? detectGeoFromBrowser();
+    if (country) {
+      addLabel(country);
+    }
+    if (continent) {
+      addLabel(continent);
     }
   }
 

--- a/ad-tag/source/ts/types/moliConfig.ts
+++ b/ad-tag/source/ts/types/moliConfig.ts
@@ -401,6 +401,19 @@ export namespace googleAdManager {
     [key: string]: string | string[] | undefined;
   }
 
+  export interface GeoConfig {
+    /**
+     * ISO 2-letter country code (e.g. `"DE"`, `"US"`).
+     * If omitted, the country is detected from the browser timezone.
+     */
+    readonly country?: string;
+    /**
+     * Continent label (e.g. `"europe"`, `"america"`).
+     * If omitted, the continent is detected from the browser timezone.
+     */
+    readonly continent?: string;
+  }
+
   export interface Targeting {
     /** static or supplied key-values */
     readonly keyValues: KeyValueMap;
@@ -417,6 +430,12 @@ export namespace googleAdManager {
 
     /** ad unit path variables */
     readonly adUnitPathVariables?: AdUnitPathVariables;
+
+    /**
+     * Optional geo configuration. Country and continent are added as labels for targeting.
+     * If not set, both values are detected automatically from the browser timezone.
+     */
+    readonly geo?: GeoConfig;
   }
 }
 

--- a/ad-tag/source/ts/util/detectGeoFromTimezone.test.ts
+++ b/ad-tag/source/ts/util/detectGeoFromTimezone.test.ts
@@ -4,69 +4,144 @@ import { detectGeoFromTimezone } from './detectGeoFromTimezone';
 describe('detectGeoFromTimezone', () => {
   describe('known country timezones', () => {
     it('should detect Germany', () => {
-      expect(detectGeoFromTimezone('Europe/Berlin')).to.deep.equal({ country: 'DE', continent: 'europe' });
+      expect(detectGeoFromTimezone('Europe/Berlin')).to.deep.equal({
+        country: 'DE',
+        continent: 'europe'
+      });
     });
 
     it('should detect United Kingdom', () => {
-      expect(detectGeoFromTimezone('Europe/London')).to.deep.equal({ country: 'GB', continent: 'europe' });
+      expect(detectGeoFromTimezone('Europe/London')).to.deep.equal({
+        country: 'GB',
+        continent: 'europe'
+      });
     });
 
     it('should detect France', () => {
-      expect(detectGeoFromTimezone('Europe/Paris')).to.deep.equal({ country: 'FR', continent: 'europe' });
+      expect(detectGeoFromTimezone('Europe/Paris')).to.deep.equal({
+        country: 'FR',
+        continent: 'europe'
+      });
     });
 
     it('should detect Spain including Canary Islands', () => {
-      expect(detectGeoFromTimezone('Europe/Madrid')).to.deep.equal({ country: 'ES', continent: 'europe' });
-      expect(detectGeoFromTimezone('Atlantic/Canary')).to.deep.equal({ country: 'ES', continent: 'atlantic' });
+      expect(detectGeoFromTimezone('Europe/Madrid')).to.deep.equal({
+        country: 'ES',
+        continent: 'europe'
+      });
+      expect(detectGeoFromTimezone('Atlantic/Canary')).to.deep.equal({
+        country: 'ES',
+        continent: 'atlantic'
+      });
     });
 
     it('should detect Portugal including island territories', () => {
-      expect(detectGeoFromTimezone('Europe/Lisbon')).to.deep.equal({ country: 'PT', continent: 'europe' });
-      expect(detectGeoFromTimezone('Atlantic/Azores')).to.deep.equal({ country: 'PT', continent: 'atlantic' });
-      expect(detectGeoFromTimezone('Atlantic/Madeira')).to.deep.equal({ country: 'PT', continent: 'atlantic' });
+      expect(detectGeoFromTimezone('Europe/Lisbon')).to.deep.equal({
+        country: 'PT',
+        continent: 'europe'
+      });
+      expect(detectGeoFromTimezone('Atlantic/Azores')).to.deep.equal({
+        country: 'PT',
+        continent: 'atlantic'
+      });
+      expect(detectGeoFromTimezone('Atlantic/Madeira')).to.deep.equal({
+        country: 'PT',
+        continent: 'atlantic'
+      });
     });
 
     it('should detect USA across multiple timezones', () => {
-      expect(detectGeoFromTimezone('America/New_York')).to.deep.equal({ country: 'US', continent: 'america' });
-      expect(detectGeoFromTimezone('America/Chicago')).to.deep.equal({ country: 'US', continent: 'america' });
-      expect(detectGeoFromTimezone('America/Los_Angeles')).to.deep.equal({ country: 'US', continent: 'america' });
-      expect(detectGeoFromTimezone('Pacific/Honolulu')).to.deep.equal({ country: 'US', continent: 'pacific' });
+      expect(detectGeoFromTimezone('America/New_York')).to.deep.equal({
+        country: 'US',
+        continent: 'america'
+      });
+      expect(detectGeoFromTimezone('America/Chicago')).to.deep.equal({
+        country: 'US',
+        continent: 'america'
+      });
+      expect(detectGeoFromTimezone('America/Los_Angeles')).to.deep.equal({
+        country: 'US',
+        continent: 'america'
+      });
+      expect(detectGeoFromTimezone('Pacific/Honolulu')).to.deep.equal({
+        country: 'US',
+        continent: 'pacific'
+      });
     });
 
     it('should detect Mexico', () => {
-      expect(detectGeoFromTimezone('America/Mexico_City')).to.deep.equal({ country: 'MX', continent: 'america' });
-      expect(detectGeoFromTimezone('America/Cancun')).to.deep.equal({ country: 'MX', continent: 'america' });
-      expect(detectGeoFromTimezone('America/Tijuana')).to.deep.equal({ country: 'MX', continent: 'america' });
+      expect(detectGeoFromTimezone('America/Mexico_City')).to.deep.equal({
+        country: 'MX',
+        continent: 'america'
+      });
+      expect(detectGeoFromTimezone('America/Cancun')).to.deep.equal({
+        country: 'MX',
+        continent: 'america'
+      });
+      expect(detectGeoFromTimezone('America/Tijuana')).to.deep.equal({
+        country: 'MX',
+        continent: 'america'
+      });
     });
   });
 
   describe('continent fallback', () => {
     it('should use africa prefix for African timezones', () => {
-      expect(detectGeoFromTimezone('Africa/Cairo')).to.deep.equal({ country: undefined, continent: 'africa' });
-      expect(detectGeoFromTimezone('Africa/Lagos')).to.deep.equal({ country: undefined, continent: 'africa' });
+      expect(detectGeoFromTimezone('Africa/Cairo')).to.deep.equal({
+        country: undefined,
+        continent: 'africa'
+      });
+      expect(detectGeoFromTimezone('Africa/Lagos')).to.deep.equal({
+        country: undefined,
+        continent: 'africa'
+      });
     });
 
     it('should use america prefix for unknown American timezones', () => {
-      expect(detectGeoFromTimezone('America/Bogota')).to.deep.equal({ country: undefined, continent: 'america' });
-      expect(detectGeoFromTimezone('America/Sao_Paulo')).to.deep.equal({ country: undefined, continent: 'america' });
+      expect(detectGeoFromTimezone('America/Bogota')).to.deep.equal({
+        country: undefined,
+        continent: 'america'
+      });
+      expect(detectGeoFromTimezone('America/Sao_Paulo')).to.deep.equal({
+        country: undefined,
+        continent: 'america'
+      });
     });
 
     it('should use europe prefix for unknown European timezones', () => {
-      expect(detectGeoFromTimezone('Europe/Athens')).to.deep.equal({ country: undefined, continent: 'europe' });
-      expect(detectGeoFromTimezone('Europe/Istanbul')).to.deep.equal({ country: undefined, continent: 'europe' });
+      expect(detectGeoFromTimezone('Europe/Athens')).to.deep.equal({
+        country: undefined,
+        continent: 'europe'
+      });
+      expect(detectGeoFromTimezone('Europe/Istanbul')).to.deep.equal({
+        country: undefined,
+        continent: 'europe'
+      });
     });
 
     it('should use asia prefix for Asian timezones', () => {
-      expect(detectGeoFromTimezone('Asia/Tokyo')).to.deep.equal({ country: undefined, continent: 'asia' });
-      expect(detectGeoFromTimezone('Asia/Shanghai')).to.deep.equal({ country: undefined, continent: 'asia' });
+      expect(detectGeoFromTimezone('Asia/Tokyo')).to.deep.equal({
+        country: undefined,
+        continent: 'asia'
+      });
+      expect(detectGeoFromTimezone('Asia/Shanghai')).to.deep.equal({
+        country: undefined,
+        continent: 'asia'
+      });
     });
 
     it('should use pacific prefix for Pacific timezones', () => {
-      expect(detectGeoFromTimezone('Pacific/Auckland')).to.deep.equal({ country: undefined, continent: 'pacific' });
+      expect(detectGeoFromTimezone('Pacific/Auckland')).to.deep.equal({
+        country: undefined,
+        continent: 'pacific'
+      });
     });
 
     it('should return undefined continent for timezones without a slash', () => {
-      expect(detectGeoFromTimezone('UTC')).to.deep.equal({ country: undefined, continent: undefined });
+      expect(detectGeoFromTimezone('UTC')).to.deep.equal({
+        country: undefined,
+        continent: undefined
+      });
     });
   });
 });

--- a/ad-tag/source/ts/util/detectGeoFromTimezone.test.ts
+++ b/ad-tag/source/ts/util/detectGeoFromTimezone.test.ts
@@ -1,0 +1,72 @@
+import { expect } from 'chai';
+import { detectGeoFromTimezone } from './detectGeoFromTimezone';
+
+describe('detectGeoFromTimezone', () => {
+  describe('known country timezones', () => {
+    it('should detect Germany', () => {
+      expect(detectGeoFromTimezone('Europe/Berlin')).to.deep.equal({ country: 'DE', continent: 'europe' });
+    });
+
+    it('should detect United Kingdom', () => {
+      expect(detectGeoFromTimezone('Europe/London')).to.deep.equal({ country: 'GB', continent: 'europe' });
+    });
+
+    it('should detect France', () => {
+      expect(detectGeoFromTimezone('Europe/Paris')).to.deep.equal({ country: 'FR', continent: 'europe' });
+    });
+
+    it('should detect Spain including Canary Islands', () => {
+      expect(detectGeoFromTimezone('Europe/Madrid')).to.deep.equal({ country: 'ES', continent: 'europe' });
+      expect(detectGeoFromTimezone('Atlantic/Canary')).to.deep.equal({ country: 'ES', continent: 'atlantic' });
+    });
+
+    it('should detect Portugal including island territories', () => {
+      expect(detectGeoFromTimezone('Europe/Lisbon')).to.deep.equal({ country: 'PT', continent: 'europe' });
+      expect(detectGeoFromTimezone('Atlantic/Azores')).to.deep.equal({ country: 'PT', continent: 'atlantic' });
+      expect(detectGeoFromTimezone('Atlantic/Madeira')).to.deep.equal({ country: 'PT', continent: 'atlantic' });
+    });
+
+    it('should detect USA across multiple timezones', () => {
+      expect(detectGeoFromTimezone('America/New_York')).to.deep.equal({ country: 'US', continent: 'america' });
+      expect(detectGeoFromTimezone('America/Chicago')).to.deep.equal({ country: 'US', continent: 'america' });
+      expect(detectGeoFromTimezone('America/Los_Angeles')).to.deep.equal({ country: 'US', continent: 'america' });
+      expect(detectGeoFromTimezone('Pacific/Honolulu')).to.deep.equal({ country: 'US', continent: 'pacific' });
+    });
+
+    it('should detect Mexico', () => {
+      expect(detectGeoFromTimezone('America/Mexico_City')).to.deep.equal({ country: 'MX', continent: 'america' });
+      expect(detectGeoFromTimezone('America/Cancun')).to.deep.equal({ country: 'MX', continent: 'america' });
+      expect(detectGeoFromTimezone('America/Tijuana')).to.deep.equal({ country: 'MX', continent: 'america' });
+    });
+  });
+
+  describe('continent fallback', () => {
+    it('should use africa prefix for African timezones', () => {
+      expect(detectGeoFromTimezone('Africa/Cairo')).to.deep.equal({ country: undefined, continent: 'africa' });
+      expect(detectGeoFromTimezone('Africa/Lagos')).to.deep.equal({ country: undefined, continent: 'africa' });
+    });
+
+    it('should use america prefix for unknown American timezones', () => {
+      expect(detectGeoFromTimezone('America/Bogota')).to.deep.equal({ country: undefined, continent: 'america' });
+      expect(detectGeoFromTimezone('America/Sao_Paulo')).to.deep.equal({ country: undefined, continent: 'america' });
+    });
+
+    it('should use europe prefix for unknown European timezones', () => {
+      expect(detectGeoFromTimezone('Europe/Athens')).to.deep.equal({ country: undefined, continent: 'europe' });
+      expect(detectGeoFromTimezone('Europe/Istanbul')).to.deep.equal({ country: undefined, continent: 'europe' });
+    });
+
+    it('should use asia prefix for Asian timezones', () => {
+      expect(detectGeoFromTimezone('Asia/Tokyo')).to.deep.equal({ country: undefined, continent: 'asia' });
+      expect(detectGeoFromTimezone('Asia/Shanghai')).to.deep.equal({ country: undefined, continent: 'asia' });
+    });
+
+    it('should use pacific prefix for Pacific timezones', () => {
+      expect(detectGeoFromTimezone('Pacific/Auckland')).to.deep.equal({ country: undefined, continent: 'pacific' });
+    });
+
+    it('should return undefined continent for timezones without a slash', () => {
+      expect(detectGeoFromTimezone('UTC')).to.deep.equal({ country: undefined, continent: undefined });
+    });
+  });
+});

--- a/ad-tag/source/ts/util/detectGeoFromTimezone.ts
+++ b/ad-tag/source/ts/util/detectGeoFromTimezone.ts
@@ -90,12 +90,3 @@ export const detectGeoFromTimezone = (timezone: string): GeoResult => {
   const country = TIMEZONE_TO_COUNTRY[timezone];
   return { country, continent: continentFromTimezone(timezone) };
 };
-
-export const detectGeoFromBrowser = (): GeoResult => {
-  try {
-    const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
-    return detectGeoFromTimezone(timezone);
-  } catch {
-    return { country: undefined, continent: undefined };
-  }
-};

--- a/ad-tag/source/ts/util/detectGeoFromTimezone.ts
+++ b/ad-tag/source/ts/util/detectGeoFromTimezone.ts
@@ -90,3 +90,12 @@ export const detectGeoFromTimezone = (timezone: string): GeoResult => {
   const country = TIMEZONE_TO_COUNTRY[timezone];
   return { country, continent: continentFromTimezone(timezone) };
 };
+
+export const detectGeoFromBrowser = (): GeoResult => {
+  try {
+    const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    return detectGeoFromTimezone(timezone);
+  } catch {
+    return { country: undefined, continent: undefined };
+  }
+};

--- a/ad-tag/source/ts/util/detectGeoFromTimezone.ts
+++ b/ad-tag/source/ts/util/detectGeoFromTimezone.ts
@@ -1,0 +1,101 @@
+export type GeoResult = {
+  readonly country: string | undefined;
+  readonly continent: string | undefined;
+};
+
+const TIMEZONE_TO_COUNTRY: Readonly<Record<string, string>> = {
+  // United Kingdom
+  'Europe/London': 'GB',
+  // Germany
+  'Europe/Berlin': 'DE',
+  // France
+  'Europe/Paris': 'FR',
+  // Italy
+  'Europe/Rome': 'IT',
+  // Spain
+  'Europe/Madrid': 'ES',
+  'Atlantic/Canary': 'ES',
+  // Netherlands
+  'Europe/Amsterdam': 'NL',
+  // Belgium
+  'Europe/Brussels': 'BE',
+  // Austria
+  'Europe/Vienna': 'AT',
+  // Switzerland
+  'Europe/Zurich': 'CH',
+  // Sweden
+  'Europe/Stockholm': 'SE',
+  // Norway
+  'Europe/Oslo': 'NO',
+  // Denmark
+  'Europe/Copenhagen': 'DK',
+  // Finland
+  'Europe/Helsinki': 'FI',
+  // Poland
+  'Europe/Warsaw': 'PL',
+  // Portugal
+  'Europe/Lisbon': 'PT',
+  'Atlantic/Madeira': 'PT',
+  'Atlantic/Azores': 'PT',
+  // Romania
+  'Europe/Bucharest': 'RO',
+  // USA
+  'America/New_York': 'US',
+  'America/Chicago': 'US',
+  'America/Denver': 'US',
+  'America/Los_Angeles': 'US',
+  'America/Phoenix': 'US',
+  'America/Anchorage': 'US',
+  'America/Adak': 'US',
+  'America/Juneau': 'US',
+  'America/Nome': 'US',
+  'America/Sitka': 'US',
+  'America/Yakutat': 'US',
+  'America/Indiana/Indianapolis': 'US',
+  'America/Indiana/Knox': 'US',
+  'America/Indiana/Marengo': 'US',
+  'America/Indiana/Petersburg': 'US',
+  'America/Indiana/Tell_City': 'US',
+  'America/Indiana/Vevay': 'US',
+  'America/Indiana/Vincennes': 'US',
+  'America/Indiana/Winamac': 'US',
+  'America/Kentucky/Louisville': 'US',
+  'America/Kentucky/Monticello': 'US',
+  'America/North_Dakota/Beulah': 'US',
+  'America/North_Dakota/Center': 'US',
+  'America/North_Dakota/New_Salem': 'US',
+  'America/Detroit': 'US',
+  'America/Menominee': 'US',
+  'Pacific/Honolulu': 'US',
+  // Mexico
+  'America/Mexico_City': 'MX',
+  'America/Monterrey': 'MX',
+  'America/Mazatlan': 'MX',
+  'America/Chihuahua': 'MX',
+  'America/Cancun': 'MX',
+  'America/Merida': 'MX',
+  'America/Tijuana': 'MX',
+  'America/Hermosillo': 'MX',
+  'America/Matamoros': 'MX',
+  'America/Ojinaga': 'MX',
+  'America/Bahia_Banderas': 'MX'
+};
+
+const continentFromTimezone = (timezone: string): string | undefined => {
+  const prefix = timezone.split('/')[0];
+  return prefix !== timezone ? prefix.toLowerCase() : undefined;
+};
+
+export const detectGeoFromTimezone = (timezone: string): GeoResult => {
+  const country = TIMEZONE_TO_COUNTRY[timezone];
+  return { country, continent: continentFromTimezone(timezone) };
+};
+
+export const detectGeoFromBrowser = (): GeoResult => {
+  try {
+    const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    return detectGeoFromTimezone(timezone);
+  } catch {
+    return { country: undefined, continent: undefined };
+  }
+};

--- a/schema.json
+++ b/schema.json
@@ -1142,6 +1142,20 @@
       },
       "type": "object"
     },
+    "googleAdManager.GeoConfig": {
+      "additionalProperties": false,
+      "properties": {
+        "continent": {
+          "description": "Continent label (e.g. `\"europe\"`, `\"america\"`). If omitted, the continent is detected from the browser timezone.",
+          "type": "string"
+        },
+        "country": {
+          "description": "ISO 2-letter country code (e.g. `\"DE\"`, `\"US\"`). If omitted, the country is detected from the browser timezone.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
     "googleAdManager.KeyValueMap": {
       "additionalProperties": {
         "anyOf": [
@@ -1191,6 +1205,10 @@
         "adUnitPathVariables": {
           "$ref": "#/definitions/AdUnitPathVariables",
           "description": "ad unit path variables"
+        },
+        "geo": {
+          "$ref": "#/definitions/googleAdManager.GeoConfig",
+          "description": "Optional geo configuration. Country and continent are added as labels for targeting. If not set, both values are detected automatically from the browser timezone."
         },
         "keyValues": {
           "$ref": "#/definitions/googleAdManager.KeyValueMap",


### PR DESCRIPTION
The ad tag now provides a lightweight and privacy friendly geo location fallback based on the browser timezone. It focuses on the European market, but can be extended to all countries.

Note that this is a fallback. The `MoliConfig` should be generated server-side and set the `targeting.geo` configuration there.

## Related

* https://github.com/prebid/Prebid.js/blob/f7ba566b7481c1539a4f54beba00bab51232c035/modules/screencoreBidAdapter.js#L26-L53