### PR TITLE
Replace deprecated method calls

### DIFF
--- a/ad-tag/source/ts/ads/a9.test.ts
+++ b/ad-tag/source/ts/ads/a9.test.ts
@@ -744,12 +744,12 @@ describe('a9', () => {
       const step = a9ClearTargetingStep();
       const slot = createSlotDefinitions(getDomId(), {});
 
-      const clearTargetingSpy = sandbox.spy(slot.adSlot, 'clearTargeting');
+      const setConfigSpy = sandbox.spy(slot.adSlot, 'setConfig');
       const getTargetingKeysStub = makeGetTargetingKeysStub(slot.adSlot);
       const ctx: AdPipelineContext = { ...adPipelineContext(), requestId__: 0 };
 
       await step(ctx, [slot]);
-      expect(clearTargetingSpy).to.have.not.been.called;
+      expect(setConfigSpy).to.have.not.been.called;
       expect(getTargetingKeysStub).to.have.not.been.called;
     });
 
@@ -757,30 +757,30 @@ describe('a9', () => {
       const step = a9ClearTargetingStep();
       const slot = createSlotDefinitions(getDomId(), {});
 
-      const clearTargetingSpy = sandbox.spy(slot.adSlot, 'clearTargeting');
+      const setConfigSpy = sandbox.spy(slot.adSlot, 'setConfig');
       const getTargetingKeysStub = makeGetTargetingKeysStub(slot.adSlot);
       const ctx: AdPipelineContext = { ...contextWithConsent, requestId__: 1 };
 
       await step(ctx, [slot]);
       expect(getTargetingKeysStub).to.have.been.calledOnce;
-      expect(clearTargetingSpy).to.have.been.calledThrice;
-      expect(clearTargetingSpy).to.have.been.calledWith('amznp');
-      expect(clearTargetingSpy).to.have.been.calledWith('amznsz');
-      expect(clearTargetingSpy).to.have.been.calledWith('amznbid');
+      expect(setConfigSpy).to.have.been.calledThrice;
+      expect(setConfigSpy).to.have.been.calledWith({ targeting: { amznp: null } });
+      expect(setConfigSpy).to.have.been.calledWith({ targeting: { amznsz: null } });
+      expect(setConfigSpy).to.have.been.calledWith({ targeting: { amznbid: null } });
     });
 
     it('should clear targeting only for the available keys', async () => {
       const step = a9ClearTargetingStep();
       const slot = createSlotDefinitions(getDomId(), {});
 
-      const clearTargetingSpy = sandbox.spy(slot.adSlot, 'clearTargeting');
+      const setConfigSpy = sandbox.spy(slot.adSlot, 'setConfig');
       const getTargetingKeysStub = makeGetTargetingKeysStub(slot.adSlot, ['amznp', 'foo']);
       const ctx: AdPipelineContext = { ...contextWithConsent, requestId__: 1 };
 
       await step(ctx, [slot]);
       expect(getTargetingKeysStub).to.have.been.calledOnce;
-      expect(clearTargetingSpy).to.have.been.calledOnce;
-      expect(clearTargetingSpy).to.have.been.calledWith('amznp');
+      expect(setConfigSpy).to.have.been.calledOnce;
+      expect(setConfigSpy).to.have.been.calledWith({ targeting: { amznp: null } });
     });
   });
 });

--- a/ad-tag/source/ts/ads/a9.ts
+++ b/ad-tag/source/ts/ads/a9.ts
@@ -203,7 +203,7 @@ export const a9ClearTargetingStep = (): PrepareRequestAdsStep =>
           adSlot
             .getTargetingKeys()
             .filter(key => key === 'amznp' || key === 'amznsz' || key === 'amznbid')
-            .forEach(key => adSlot.clearTargeting(key));
+            .forEach(key => adSlot.setConfig({ targeting: { [key]: null } }));
         });
         resolve();
       });

--- a/ad-tag/source/ts/ads/auctions/frequencyCapping.test.ts
+++ b/ad-tag/source/ts/ads/auctions/frequencyCapping.test.ts
@@ -87,8 +87,8 @@ describe('FrequencyCapping', () => {
   afterEach(() => {
     sandbox.reset();
     sandbox.clock.restore();
-    wpSlot.clearTargeting();
-    interstitalSlot.clearTargeting();
+    wpSlot.setConfig({ targeting: null });
+    interstitalSlot.setConfig({ targeting: null });
   });
 
   it('should not add a frequency cap if configs are empty', () => {

--- a/ad-tag/source/ts/ads/auctions/interstitialContext.test.ts
+++ b/ad-tag/source/ts/ads/auctions/interstitialContext.test.ts
@@ -71,7 +71,7 @@ describe('InterstitialContext', () => {
   afterEach(() => {
     sandbox.reset();
     jsDomWindow.sessionStorage.clear();
-    slot.clearTargeting();
+    slot.setConfig({ targeting: null });
   });
 
   describe('gam only setup', () => {
@@ -237,7 +237,7 @@ describe('InterstitialContext', () => {
     };
 
     beforeEach(() => {
-      slot.clearTargeting();
+      slot.setConfig({ targeting: null });
     });
 
     it('should use resolved ad unit path in onSlotRenderEnded to skip events', () => {

--- a/ad-tag/source/ts/ads/googleAdManager.test.ts
+++ b/ad-tag/source/ts/ads/googleAdManager.test.ts
@@ -138,17 +138,17 @@ describe('google ad manager', () => {
   });
 
   describe('gptConfigure', () => {
-    it('setTargeting should not be called if targeting is empty', async () => {
+    it('setConfig should not be called with targeting if targeting is empty', async () => {
       const step = gptConfigure();
-      const setTargetingSpy = sandbox.spy(dom.window.googletag.pubads(), 'setTargeting');
+      const setConfigSpy = sandbox.spy(dom.window.googletag, 'setConfig');
 
       await step(adPipelineContext(), []);
-      expect(setTargetingSpy).to.have.not.been.called;
+      expect(setConfigSpy).to.have.not.been.called;
     });
 
-    it('setTargeting should be called if targeting contains key-values', async () => {
+    it('setConfig should be called with targeting if targeting contains key-values', async () => {
       const step = gptConfigure();
-      const setTargetingSpy = sandbox.spy(dom.window.googletag.pubads(), 'setTargeting');
+      const setConfigSpy = sandbox.spy(dom.window.googletag, 'setConfig');
 
       const configWithServerSideTargeting: MoliConfig = {
         ...emptyConfig,
@@ -161,14 +161,13 @@ describe('google ad manager', () => {
       };
 
       await step(adPipelineContext('production', configWithServerSideTargeting), []);
-      expect(setTargetingSpy).to.have.been.calledTwice;
-      expect(setTargetingSpy).to.have.been.calledWith('foo', 'bar');
-      expect(setTargetingSpy).to.have.been.calledWith('tags', ['one', 'two']);
+      expect(setConfigSpy).to.have.been.calledOnce;
+      expect(setConfigSpy).to.have.been.calledWith({ targeting: { foo: 'bar', tags: ['one', 'two'] } });
     });
 
-    it('setTargeting should not be called if targeting key-value is excluded', async () => {
+    it('setConfig should not include excluded targeting key-values', async () => {
       const step = gptConfigure();
-      const setTargetingSpy = sandbox.spy(dom.window.googletag.pubads(), 'setTargeting');
+      const setConfigSpy = sandbox.spy(dom.window.googletag, 'setConfig');
 
       const configWithServerSideTargeting: MoliConfig = {
         ...emptyConfig,
@@ -182,8 +181,8 @@ describe('google ad manager', () => {
       };
 
       await step(adPipelineContext('production', configWithServerSideTargeting), []);
-      expect(setTargetingSpy).to.have.been.calledOnce;
-      expect(setTargetingSpy).to.have.been.calledWith('foo', 'bar');
+      expect(setConfigSpy).to.have.been.calledOnce;
+      expect(setConfigSpy).to.have.been.calledWith({ targeting: { foo: 'bar' } });
     });
   });
 
@@ -334,14 +333,10 @@ describe('google ad manager', () => {
         }
       };
       const setConfigSpy = sandbox.spy(dom.window.googletag, 'setConfig');
-      const setTargetingSpy = sandbox.spy(dom.window.googletag.pubads(), 'setTargeting');
       await step(adPipelineContext('production', configWithTargeting), []);
-      Sinon.assert.callOrder(setConfigSpy, setTargetingSpy);
-      expect(setConfigSpy).to.have.been.calledOnce;
-      expect(setConfigSpy).calledWith({ targeting: null });
-      expect(setTargetingSpy).to.have.been.calledTwice;
-      expect(setTargetingSpy).to.have.been.calledWith('foo', 'bar');
-      expect(setTargetingSpy).to.have.been.calledWith('tags', ['car', 'truck']);
+      expect(setConfigSpy).to.have.been.calledTwice;
+      expect(setConfigSpy.firstCall).calledWith({ targeting: null });
+      expect(setConfigSpy.secondCall).calledWith({ targeting: { foo: 'bar', tags: ['car', 'truck'] } });
     });
 
     it('should only be executed once per requestAds cycle', async () => {
@@ -413,68 +408,68 @@ describe('google ad manager', () => {
 
     it('should set mobile as a device label', async () => {
       const step = gptLDeviceLabelKeyValue();
-      const setTargetingSpy = sandbox.spy(dom.window.googletag.pubads(), 'setTargeting');
+      const setConfigSpy = sandbox.spy(dom.window.googletag, 'setConfig');
       getDeviceLabelStub.returns('mobile');
       await step(ctxWithLabelServiceStub, []);
-      expect(setTargetingSpy).to.have.been.calledOnce;
-      expect(setTargetingSpy).to.have.been.calledWith('device_label', 'mobile');
+      expect(setConfigSpy).to.have.been.calledOnce;
+      expect(setConfigSpy).to.have.been.calledWith({ targeting: { device_label: 'mobile' } });
     });
 
     it('should set desktop as a device label', async () => {
       const step = gptLDeviceLabelKeyValue();
-      const setTargetingSpy = sandbox.spy(dom.window.googletag.pubads(), 'setTargeting');
+      const setConfigSpy = sandbox.spy(dom.window.googletag, 'setConfig');
 
       getDeviceLabelStub.returns('desktop');
 
       await step(ctxWithLabelServiceStub, []);
-      expect(setTargetingSpy).to.have.been.calledOnce;
-      expect(setTargetingSpy).to.have.been.calledWith('device_label', 'desktop');
+      expect(setConfigSpy).to.have.been.calledOnce;
+      expect(setConfigSpy).to.have.been.calledWith({ targeting: { device_label: 'desktop' } });
     });
 
-    it('should not call googletag.pubads.setTargeting in env test', async () => {
+    it('should not call googletag.setConfig in env test', async () => {
       const step = gptLDeviceLabelKeyValue();
-      const setTargetingSpy = sandbox.spy(dom.window.googletag.pubads(), 'setTargeting');
+      const setConfigSpy = sandbox.spy(dom.window.googletag, 'setConfig');
       getDeviceLabelStub.returns('mobile');
 
       await step(adPipelineContext('test'), []);
-      expect(setTargetingSpy).to.have.not.been.called;
+      expect(setConfigSpy).to.have.not.been.called;
     });
   });
 
   describe('gptConsentKeyValue', () => {
     it('should set full if gdpr does not apply', async () => {
-      const setTargetingSpy = sandbox.spy(dom.window.googletag.pubads(), 'setTargeting');
+      const setConfigSpy = sandbox.spy(dom.window.googletag, 'setConfig');
       const step = gptConsentKeyValue();
       await step({ ...adPipelineContext(), tcData__: tcDataNoGdpr }, []);
-      expect(setTargetingSpy).to.have.been.calledOnce;
-      expect(setTargetingSpy).to.have.been.calledOnceWithExactly('consent', 'full');
+      expect(setConfigSpy).to.have.been.calledOnce;
+      expect(setConfigSpy).to.have.been.calledOnceWithExactly({ targeting: { consent: 'full' } });
     });
 
     it('should set full if consent is available for all purposes', async () => {
-      const setTargetingSpy = sandbox.spy(dom.window.googletag.pubads(), 'setTargeting');
+      const setConfigSpy = sandbox.spy(dom.window.googletag, 'setConfig');
       const step = gptConsentKeyValue();
       await step(adPipelineContext(), []);
-      expect(setTargetingSpy).to.have.been.calledOnce;
-      expect(setTargetingSpy).to.have.been.calledOnceWithExactly('consent', 'full');
+      expect(setConfigSpy).to.have.been.calledOnce;
+      expect(setConfigSpy).to.have.been.calledOnceWithExactly({ targeting: { consent: 'full' } });
     });
 
     ['1', '2', '3', '4', '7', '9', '10'].forEach(purpose => {
       it(`should set none if consent is missing for purpose ${purpose}`, async () => {
-        const setTargetingSpy = sandbox.spy(dom.window.googletag.pubads(), 'setTargeting');
+        const setConfigSpy = sandbox.spy(dom.window.googletag, 'setConfig');
         const step = gptConsentKeyValue();
         const tcData = fullConsent();
         tcData.purpose.consents[purpose] = false;
 
         await step({ ...adPipelineContext(), tcData__: tcData }, []);
-        expect(setTargetingSpy).to.have.been.calledOnceWithExactly('consent', 'none');
+        expect(setConfigSpy).to.have.been.calledOnceWithExactly({ targeting: { consent: 'none' } });
       });
     });
 
-    it('should not call googletag.pubads.setTargeting in env test', async () => {
-      const setTargetingSpy = sandbox.spy(dom.window.googletag.pubads(), 'setTargeting');
+    it('should not call googletag.setConfig in env test', async () => {
+      const setConfigSpy = sandbox.spy(dom.window.googletag, 'setConfig');
       const step = gptConsentKeyValue();
       await step(adPipelineContext('test'), []);
-      expect(setTargetingSpy).to.have.not.been.called;
+      expect(setConfigSpy).to.have.not.been.called;
     });
   });
 
@@ -540,7 +535,7 @@ describe('google ad manager', () => {
         );
         expect(addServiceSpy).to.have.been.calledOnce;
         expect(addServiceSpy).to.have.been.calledOnceWithExactly(dom.window.googletag.pubads());
-        expect(setSlotConfigSpy).to.have.been.calledOnceWithExactly(gptSlotSettings);
+        expect(setSlotConfigSpy).to.have.been.calledWith(gptSlotSettings);
         expect(displaySpy).to.have.been.calledOnce;
         expect(displaySpy).to.have.been.calledOnceWithExactly(adSlotStub);
         expect(slotDefinitions).to.have.length(1);
@@ -576,7 +571,7 @@ describe('google ad manager', () => {
         );
         expect(addServiceSpy).to.have.been.calledOnce;
         expect(addServiceSpy).to.have.been.calledOnceWithExactly(dom.window.googletag.pubads());
-        expect(setSlotConfigSpy).to.have.been.calledOnceWithExactly(gptSlotSettings);
+        expect(setSlotConfigSpy).to.have.been.calledWith(gptSlotSettings);
         expect(displaySpy).to.have.been.calledOnce;
         expect(displaySpy).to.have.been.calledOnceWithExactly(adSlotStub);
         expect(slotDefinitions).to.have.length(1);
@@ -622,7 +617,7 @@ describe('google ad manager', () => {
         );
         expect(addServiceSpy).to.have.been.calledOnce;
         expect(addServiceSpy).to.have.been.calledOnceWithExactly(dom.window.googletag.pubads());
-        expect(setSlotConfigSpy).to.have.been.calledOnceWithExactly(gptSlotSettings);
+        expect(setSlotConfigSpy).to.have.been.calledWith(gptSlotSettings);
         expect(displaySpy).to.have.been.calledOnce;
         expect(displaySpy).to.have.been.calledOnceWithExactly(adSlotStub);
         expect(slotDefinitions).to.have.length(1);
@@ -704,7 +699,7 @@ describe('google ad manager', () => {
         );
         expect(addServiceSpy).to.have.been.calledOnce;
         expect(addServiceSpy).to.have.been.calledOnceWithExactly(dom.window.googletag.pubads());
-        expect(setSlotConfigSpy).to.have.been.calledOnceWithExactly(gptSlotSettings);
+        expect(setSlotConfigSpy).to.have.been.calledWith(gptSlotSettings);
         expect(displaySpy).to.have.been.calledOnce;
         expect(displaySpy).to.have.been.calledOnceWithExactly(adSlotStub);
         expect(slotDefinitions).to.have.length(1);
@@ -824,7 +819,7 @@ describe('google ad manager', () => {
         expect(defineOutOfPageSlotStub).to.have.been.calledOnceWithExactly('/123/dom-id/mobile', 2);
         expect(addServiceSpy).to.have.been.calledOnce;
         expect(addServiceSpy).to.have.been.calledOnceWithExactly(dom.window.googletag.pubads());
-        expect(setSlotConfigSpy).to.have.been.calledOnceWithExactly(gptSlotSettings);
+        expect(setSlotConfigSpy).to.have.been.calledWith(gptSlotSettings);
         expect(displaySpy).to.have.been.calledOnce;
         expect(displaySpy).to.have.been.calledOnceWithExactly(adSlotStub);
         expect(slotDefinitions).to.have.length(1);
@@ -873,7 +868,7 @@ describe('google ad manager', () => {
         expect(defineOutOfPageSlotStub).to.have.been.calledOnceWithExactly('/123/dom-id/mobile', 3);
         expect(addServiceSpy).to.have.been.calledOnce;
         expect(addServiceSpy).to.have.been.calledOnceWithExactly(dom.window.googletag.pubads());
-        expect(setSlotConfigSpy).to.have.been.calledOnceWithExactly(gptSlotSettings);
+        expect(setSlotConfigSpy).to.have.been.calledWith(gptSlotSettings);
         expect(displaySpy).to.have.been.calledOnce;
         expect(displaySpy).to.have.been.calledOnceWithExactly(adSlotStub);
         expect(slotDefinitions).to.have.length(1);
@@ -989,7 +984,7 @@ describe('google ad manager', () => {
 
       it('should set to true if undefined', async () => {
         await defineSlots();
-        expect(setConfig).to.have.been.calledOnceWithExactly({ collapseDiv: undefined });
+        expect(setConfig).to.have.been.calledWith({ collapseDiv: undefined });
       });
 
       const behaviours: googletag.GptCollapseDivBehavior[] = [
@@ -1000,7 +995,7 @@ describe('google ad manager', () => {
       behaviours.forEach(behaviour => {
         it(`should set to ${behaviour} if ${behaviour}`, async () => {
           await defineSlots(behaviour);
-          expect(setConfig).to.have.been.calledOnceWithExactly({ collapseDiv: behaviour });
+          expect(setConfig).to.have.been.calledWith({ collapseDiv: behaviour });
         });
       });
     });

--- a/ad-tag/source/ts/ads/googleAdManager.test.ts
+++ b/ad-tag/source/ts/ads/googleAdManager.test.ts
@@ -162,7 +162,9 @@ describe('google ad manager', () => {
 
       await step(adPipelineContext('production', configWithServerSideTargeting), []);
       expect(setConfigSpy).to.have.been.calledOnce;
-      expect(setConfigSpy).to.have.been.calledWith({ targeting: { foo: 'bar', tags: ['one', 'two'] } });
+      expect(setConfigSpy).to.have.been.calledWith({
+        targeting: { foo: 'bar', tags: ['one', 'two'] }
+      });
     });
 
     it('setConfig should not include excluded targeting key-values', async () => {
@@ -336,7 +338,9 @@ describe('google ad manager', () => {
       await step(adPipelineContext('production', configWithTargeting), []);
       expect(setConfigSpy).to.have.been.calledTwice;
       expect(setConfigSpy.firstCall).calledWith({ targeting: null });
-      expect(setConfigSpy.secondCall).calledWith({ targeting: { foo: 'bar', tags: ['car', 'truck'] } });
+      expect(setConfigSpy.secondCall).calledWith({
+        targeting: { foo: 'bar', tags: ['car', 'truck'] }
+      });
     });
 
     it('should only be executed once per requestAds cycle', async () => {

--- a/ad-tag/source/ts/ads/googleAdManager.ts
+++ b/ad-tag/source/ts/ads/googleAdManager.ts
@@ -55,9 +55,6 @@ const testAdSlot = (domId: string, adUnitPath: string): googletag.IAdSlot => ({
     return [];
   },
 
-  clearTargeting(_key?: string): void {
-    return;
-  },
   getResponseInformation(): null | googletag.IResponseInformation {
     return null;
   },
@@ -78,18 +75,17 @@ const configureTargeting = (
   const staticKeyValues = serverSideTargeting ? serverSideTargeting.keyValues : {};
   const excludes = serverSideTargeting?.adManagerExcludes ?? [];
 
-  // first use the static targeting and override if necessary with the runtime key values
-  // TODO use googletag.setConfig(targeting) instead as setTargeting is deprecated
+  const targeting: Record<string, string | string[]> = {};
   [staticKeyValues, runtimeKeyValues].forEach(keyValues => {
-    Object.keys(keyValues)
-      .filter(key => !excludes.includes(key))
-      .forEach(key => {
-        const value = keyValues[key];
-        if (value) {
-          window.googletag.pubads().setTargeting(key, value);
-        }
-      });
+    Object.entries(keyValues).forEach(([key, value]) => {
+      if (!excludes.includes(key) && value) {
+        targeting[key] = value;
+      }
+    });
   });
+  if (Object.keys(targeting).length > 0) {
+    window.googletag.setConfig({ targeting });
+  }
 };
 
 /**
@@ -295,7 +291,7 @@ export const gptLDeviceLabelKeyValue = (): PrepareRequestAdsStep =>
     return new Promise<void>(resolve => {
       const deviceLabel = ctx.labelConfigService__.getDeviceLabel();
       ctx.logger__.debug('GAM', 'adding "device_label" key-value with values', deviceLabel);
-      ctx.window__.googletag.pubads().setTargeting('device_label', deviceLabel);
+      ctx.window__.googletag.setConfig({ targeting: { device_label: deviceLabel } });
 
       resolve();
     });
@@ -329,7 +325,7 @@ export const gptConsentKeyValue = (): PrepareRequestAdsStep =>
           tcfapi.responses.TCPurpose.APPLY_MARKET_RESEARCH,
           tcfapi.responses.TCPurpose.DEVELOP_IMPROVE_PRODUCTS
         ].every(purpose => tcData.purpose.consents[purpose]);
-      ctx.window__.googletag.pubads().setTargeting('consent', fullConsent ? 'full' : 'none');
+      ctx.window__.googletag.setConfig({ targeting: { consent: fullConsent ? 'full' : 'none' } });
       resolve();
     });
   });
@@ -468,7 +464,7 @@ export const gptDefineSlots =
             }
             // GAM interstitials already have format set above via the format parameter
           } else {
-            adSlot.clearTargeting(formatKey);
+            adSlot.setConfig({ targeting: { [formatKey]: null } });
           }
 
           // required method call, but doesn't trigger ad loading as we use the disableInitialLoad

--- a/ad-tag/source/ts/ads/modules/blocklist-url/index.test.ts
+++ b/ad-tag/source/ts/ads/modules/blocklist-url/index.test.ts
@@ -328,7 +328,9 @@ describe('BlocklistedUrls Module', () => {
             const { initStep, config } = createInitializedModule([pattern]);
             return initStep(adPipelineContext(config), []).then(() => {
               expect(setConfigSpy).to.have.been.calledOnce;
-              expect(setConfigSpy).to.have.been.calledOnceWithExactly({ targeting: { isBlocklisted: 'true' } });
+              expect(setConfigSpy).to.have.been.calledOnceWithExactly({
+                targeting: { isBlocklisted: 'true' }
+              });
             });
           })
         );
@@ -336,7 +338,9 @@ describe('BlocklistedUrls Module', () => {
           const { initStep, config } = createInitializedModule(['blocklisted'], 'yes');
           return initStep(adPipelineContext(config), []).then(() => {
             expect(setConfigSpy).to.have.been.calledOnce;
-            expect(setConfigSpy).to.have.been.calledOnceWithExactly({ targeting: { isBlocklisted: 'yes' } });
+            expect(setConfigSpy).to.have.been.calledOnceWithExactly({
+              targeting: { isBlocklisted: 'yes' }
+            });
           });
         });
       });

--- a/ad-tag/source/ts/ads/modules/blocklist-url/index.test.ts
+++ b/ad-tag/source/ts/ads/modules/blocklist-url/index.test.ts
@@ -31,7 +31,7 @@ use(chaiAsPromised);
 
 describe('BlocklistedUrls Module', () => {
   const sandbox = Sinon.createSandbox();
-  let assetLoaderService, loadJsonStub, googleTagStub, setTargetingSpy;
+  let assetLoaderService, loadJsonStub, googleTagStub, setConfigSpy;
   let { dom, jsDomWindow } = createDomAndWindow();
 
   const setupDomAndServices = () => {
@@ -41,7 +41,7 @@ describe('BlocklistedUrls Module', () => {
     assetLoaderService = createAssetLoaderService(jsDomWindow);
     loadJsonStub = sandbox.stub(assetLoaderService, 'loadJson');
     googleTagStub = createGoogletagStub();
-    setTargetingSpy = sandbox.spy(googleTagStub.pubads(), 'setTargeting');
+    setConfigSpy = sandbox.spy(googleTagStub, 'setConfig');
     jsDomWindow.googletag = googleTagStub;
   };
 
@@ -300,14 +300,14 @@ describe('BlocklistedUrls Module', () => {
       it('should add an init step that sets not key values if no blocklisted urls are defined', async () => {
         const { initStep, config } = createInitializedModule([]);
         return initStep(adPipelineContext(config), []).then(() => {
-          expect(setTargetingSpy).to.have.not.been.called;
+          expect(setConfigSpy).to.have.not.been.called;
         });
       });
 
       it('should add an init step that resolves if no blocklisted urls are found', () => {
         const { initStep, config } = createInitializedModule(['foo']);
         return initStep(adPipelineContext(config), []).then(() => {
-          expect(setTargetingSpy).to.have.not.been.called;
+          expect(setConfigSpy).to.have.not.been.called;
         });
       });
 
@@ -327,16 +327,16 @@ describe('BlocklistedUrls Module', () => {
           it(`should match pattern ${pattern}`, async () => {
             const { initStep, config } = createInitializedModule([pattern]);
             return initStep(adPipelineContext(config), []).then(() => {
-              expect(setTargetingSpy).to.have.been.calledOnce;
-              expect(setTargetingSpy).to.have.been.calledOnceWithExactly('isBlocklisted', 'true');
+              expect(setConfigSpy).to.have.been.calledOnce;
+              expect(setConfigSpy).to.have.been.calledOnceWithExactly({ targeting: { isBlocklisted: 'true' } });
             });
           })
         );
         it('should set a custom key-value value', async () => {
           const { initStep, config } = createInitializedModule(['blocklisted'], 'yes');
           return initStep(adPipelineContext(config), []).then(() => {
-            expect(setTargetingSpy).to.have.been.calledOnce;
-            expect(setTargetingSpy).to.have.been.calledOnceWithExactly('isBlocklisted', 'yes');
+            expect(setConfigSpy).to.have.been.calledOnce;
+            expect(setConfigSpy).to.have.been.calledOnceWithExactly({ targeting: { isBlocklisted: 'yes' } });
           });
         });
       });

--- a/ad-tag/source/ts/ads/modules/blocklist-url/index.ts
+++ b/ad-tag/source/ts/ads/modules/blocklist-url/index.ts
@@ -211,8 +211,7 @@ export const createBlocklistedUrls = (): IModule => {
                 )().then(blocklist => {
                   if (isBlocklisted(blocklist, ctx.window__.location.href, ctx.logger__)) {
                     (ctx.window__ as Window & googletag.IGoogleTagWindow).googletag
-                      .pubads()
-                      .setTargeting(key, value);
+                      .setConfig({ targeting: { [key]: value } });
                   }
                 });
               case 'block':

--- a/ad-tag/source/ts/ads/modules/blocklist-url/index.ts
+++ b/ad-tag/source/ts/ads/modules/blocklist-url/index.ts
@@ -210,8 +210,9 @@ export const createBlocklistedUrls = (): IModule => {
                   ctx.logger__
                 )().then(blocklist => {
                   if (isBlocklisted(blocklist, ctx.window__.location.href, ctx.logger__)) {
-                    (ctx.window__ as Window & googletag.IGoogleTagWindow).googletag
-                      .setConfig({ targeting: { [key]: value } });
+                    (ctx.window__ as Window & googletag.IGoogleTagWindow).googletag.setConfig({
+                      targeting: { [key]: value }
+                    });
                   }
                 });
               case 'block':

--- a/ad-tag/source/ts/ads/modules/generic-skin/index.test.ts
+++ b/ad-tag/source/ts/ads/modules/generic-skin/index.test.ts
@@ -761,7 +761,7 @@ describe('Skin Module', () => {
       );
 
       it('should set page level targeting if a skin is selected', () => {
-        const setTargetingSpy = sandbox.spy(jsDomWindow.googletag.pubads(), 'setTargeting');
+        const setConfigSpy = sandbox.spy(jsDomWindow.googletag, 'setConfig');
         const configuredModule = skinModule({ configs: [skinConfig] });
         const runner = configuredModule.runSkinConfigs({
           enabled: true,
@@ -776,12 +776,12 @@ describe('Skin Module', () => {
           slotDefinitions
         );
 
-        expect(setTargetingSpy).to.have.been.calledOnce;
-        expect(setTargetingSpy).to.have.been.calledWithExactly('skin', '1');
+        expect(setConfigSpy).to.have.been.calledOnce;
+        expect(setConfigSpy).to.have.been.calledWithExactly({ targeting: { skin: '1' } });
       });
 
       it('should set page level targeting with the given value', () => {
-        const setTargetingSpy = sandbox.spy(jsDomWindow.googletag.pubads(), 'setTargeting');
+        const setConfigSpy = sandbox.spy(jsDomWindow.googletag, 'setConfig');
 
         const skinConfigWithValue: modules.skin.SkinConfig = {
           ...skinConfig,
@@ -804,12 +804,12 @@ describe('Skin Module', () => {
           slotDefinitions
         );
 
-        expect(setTargetingSpy).to.have.been.calledOnce;
-        expect(setTargetingSpy).to.have.been.calledWithExactly('skin', 'foo');
+        expect(setConfigSpy).to.have.been.calledOnce;
+        expect(setConfigSpy).to.have.been.calledWithExactly({ targeting: { skin: 'foo' } });
       });
 
       it('should not set page level targeting if no skin is selected', () => {
-        const setTargetingSpy = sandbox.spy(jsDomWindow.googletag.pubads(), 'setTargeting');
+        const setConfigSpy = sandbox.spy(jsDomWindow.googletag, 'setConfig');
         const configuredModule = skinModule({ configs: [skinConfig] });
 
         const runner = configuredModule.runSkinConfigs({
@@ -825,7 +825,7 @@ describe('Skin Module', () => {
           slotDefinitions
         );
 
-        expect(setTargetingSpy).to.have.not.been.called;
+        expect(setConfigSpy).to.have.not.been.called;
       });
     });
   });

--- a/ad-tag/source/ts/ads/modules/generic-skin/index.ts
+++ b/ad-tag/source/ts/ads/modules/generic-skin/index.ts
@@ -246,8 +246,7 @@ export const createSkin = (): ISkinModule => {
           if (skinConfig.targeting) {
             try {
               ctx.window__.googletag
-                .pubads()
-                .setTargeting(skinConfig.targeting.key, skinConfig.targeting.value ?? '1');
+                .setConfig({ targeting: { [skinConfig.targeting.key]: skinConfig.targeting.value ?? '1' } });
             } catch (e) {
               ctx.logger__.error('SkinModule', e);
             }

--- a/ad-tag/source/ts/ads/modules/generic-skin/index.ts
+++ b/ad-tag/source/ts/ads/modules/generic-skin/index.ts
@@ -245,8 +245,9 @@ export const createSkin = (): ISkinModule => {
 
           if (skinConfig.targeting) {
             try {
-              ctx.window__.googletag
-                .setConfig({ targeting: { [skinConfig.targeting.key]: skinConfig.targeting.value ?? '1' } });
+              ctx.window__.googletag.setConfig({
+                targeting: { [skinConfig.targeting.key]: skinConfig.targeting.value ?? '1' }
+              });
             } catch (e) {
               ctx.logger__.error('SkinModule', e);
             }

--- a/ad-tag/source/ts/ads/modules/pubstack/index.test.ts
+++ b/ad-tag/source/ts/ads/modules/pubstack/index.test.ts
@@ -24,7 +24,7 @@ describe('Pubstack Module', () => {
   const { jsDomWindow } = createDomAndWindow();
 
   const googletagStub = createGoogletagStub();
-  const setTargetingSpy = sandbox.spy(googletagStub.pubads(), 'setTargeting');
+  const setConfigSpy = sandbox.spy(googletagStub, 'setConfig');
 
   jsDomWindow.googletag = googletagStub;
 
@@ -139,14 +139,14 @@ describe('Pubstack Module', () => {
 
     it('should do nothing if the meta tag is missing', async () => {
       await callConfigureStep();
-      expect(setTargetingSpy).to.have.not.been.called;
+      expect(setConfigSpy).to.have.not.been.called;
     });
 
     ['-1', '4', '5', 'five', 'true', 'false'].forEach(content => {
       it(`should ignore invalid value "${content}"`, async () => {
         addMetaTag(content);
         await callConfigureStep();
-        expect(setTargetingSpy).to.have.not.been.called;
+        expect(setConfigSpy).to.have.not.been.called;
       });
     });
 
@@ -154,13 +154,13 @@ describe('Pubstack Module', () => {
       it(`should set pubstack key value with "${content}"`, async () => {
         addMetaTag(content);
         await callConfigureStep();
-        expect(setTargetingSpy).to.have.been.called;
+        expect(setConfigSpy).to.have.been.called;
       });
 
       it(`should do nothing if env is test with valid value ${content}`, async () => {
         addMetaTag(content);
         await callConfigureStep('test');
-        expect(setTargetingSpy).to.have.not.been.called;
+        expect(setConfigSpy).to.have.not.been.called;
       });
     });
   });

--- a/ad-tag/source/ts/ads/modules/pubstack/index.ts
+++ b/ad-tag/source/ts/ads/modules/pubstack/index.ts
@@ -83,7 +83,7 @@ export const createPubstack = (): IModule => {
             }
             const pubstackAbTestCohort = extractPubstackAbTestCohort(ctx);
             if (pubstackAbTestCohort) {
-              ctx.window__.googletag.pubads().setTargeting('pbstck_ab_test', pubstackAbTestCohort);
+              ctx.window__.googletag.setConfig({ targeting: { pbstck_ab_test: pubstackAbTestCohort } });
             }
 
             return Promise.resolve();

--- a/ad-tag/source/ts/ads/modules/pubstack/index.ts
+++ b/ad-tag/source/ts/ads/modules/pubstack/index.ts
@@ -83,7 +83,9 @@ export const createPubstack = (): IModule => {
             }
             const pubstackAbTestCohort = extractPubstackAbTestCohort(ctx);
             if (pubstackAbTestCohort) {
-              ctx.window__.googletag.setConfig({ targeting: { pbstck_ab_test: pubstackAbTestCohort } });
+              ctx.window__.googletag.setConfig({
+                targeting: { pbstck_ab_test: pubstackAbTestCohort }
+              });
             }
 
             return Promise.resolve();

--- a/ad-tag/source/ts/ads/modules/yield-optimization/index.test.ts
+++ b/ad-tag/source/ts/ads/modules/yield-optimization/index.test.ts
@@ -266,7 +266,7 @@ describe('Yield Optimization module', () => {
         yieldOptimizationService
       );
 
-      const setTargetingSpy = sandbox.spy(jsDomWindow.googletag.pubads(), 'setTargeting');
+      const setConfigSpy = sandbox.spy(jsDomWindow.googletag, 'setConfig');
 
       const getBrowserStub = sandbox
         .stub(yieldOptimizationService, 'getBrowser')
@@ -275,8 +275,8 @@ describe('Yield Optimization module', () => {
       await prepareRequestAdsStep(newAdPipelineContext(jsDomWindow), []);
 
       expect(getBrowserStub).to.have.been.calledOnce;
-      expect(setTargetingSpy).to.have.been.calledOnce;
-      expect(setTargetingSpy).to.have.been.calledOnceWithExactly('upr_browser', 'Chrome');
+      expect(setConfigSpy).to.have.been.calledOnce;
+      expect(setConfigSpy).to.have.been.calledOnceWithExactly({ targeting: { upr_browser: 'Chrome' } });
     });
   });
 });

--- a/ad-tag/source/ts/ads/modules/yield-optimization/index.test.ts
+++ b/ad-tag/source/ts/ads/modules/yield-optimization/index.test.ts
@@ -276,7 +276,9 @@ describe('Yield Optimization module', () => {
 
       expect(getBrowserStub).to.have.been.calledOnce;
       expect(setConfigSpy).to.have.been.calledOnce;
-      expect(setConfigSpy).to.have.been.calledOnceWithExactly({ targeting: { upr_browser: 'Chrome' } });
+      expect(setConfigSpy).to.have.been.calledOnceWithExactly({
+        targeting: { upr_browser: 'Chrome' }
+      });
     });
   });
 });

--- a/ad-tag/source/ts/ads/modules/yield-optimization/index.ts
+++ b/ad-tag/source/ts/ads/modules/yield-optimization/index.ts
@@ -161,7 +161,7 @@ export const YieldOptimization = (
           .then(() => yieldOptimizationService.getBrowser())
           .then(browser => {
             if (context.env__ === 'production' && adServer === 'gam') {
-              context.window__.googletag.pubads().setTargeting('upr_browser', browser);
+              context.window__.googletag.setConfig({ targeting: { upr_browser: browser } });
             }
           });
       }

--- a/ad-tag/source/ts/ads/moli.test.ts
+++ b/ad-tag/source/ts/ads/moli.test.ts
@@ -1056,10 +1056,7 @@ describe('moli', () => {
     });
 
     it('should persists the initial key-values in spa mode for all requestAd() calls', async () => {
-      const googletagPubAdsSetTargetingSpy = sandbox.spy(
-        jsDomWindow.googletag.pubads(),
-        'setTargeting'
-      );
+      const googletagSetConfigSpy = sandbox.spy(jsDomWindow.googletag, 'setConfig');
       dom.reconfigure({
         url: 'https://localhost/1'
       });
@@ -1084,12 +1081,12 @@ describe('moli', () => {
       const spaState1: ISinglePageApp = state as ISinglePageApp;
       expect(spaState1.config).to.be.ok;
       expect(spaState1.nextRuntimeConfig.keyValues).to.be.deep.equal({});
-      expect(googletagPubAdsSetTargetingSpy).calledWithExactly('dynamicKeyValuePre', 'value');
-      expect(googletagPubAdsSetTargetingSpy).calledWithExactly('dynamicKeyValuePost', 'value');
-      expect(googletagPubAdsSetTargetingSpy).calledWithExactly('keyFromAdConfig', 'value');
-      expect(googletagPubAdsSetTargetingSpy).calledWithMatch('ABtest', Sinon.match.any);
+      expect(googletagSetConfigSpy).calledWithMatch({ targeting: Sinon.match.has('dynamicKeyValuePre', 'value') });
+      expect(googletagSetConfigSpy).calledWithMatch({ targeting: Sinon.match.has('dynamicKeyValuePost', 'value') });
+      expect(googletagSetConfigSpy).calledWithMatch({ targeting: Sinon.match.has('keyFromAdConfig', 'value') });
+      expect(googletagSetConfigSpy).calledWithMatch({ targeting: Sinon.match.has('ABtest', Sinon.match.any) });
 
-      googletagPubAdsSetTargetingSpy.resetHistory();
+      googletagSetConfigSpy.resetHistory();
       dom.reconfigure({
         url: 'https://localhost/2'
       });
@@ -1115,11 +1112,11 @@ describe('moli', () => {
       expect(keyValues).to.not.have.property('dynamicKeyValuePre', 'value');
       expect(keyValues).to.not.have.property('dynamicKeyValuePost', 'value');
 
-      expect(googletagPubAdsSetTargetingSpy.callCount).to.be.gte(4);
-      expect(googletagPubAdsSetTargetingSpy).calledWithExactly('keyFromAdConfig', 'value');
-      expect(googletagPubAdsSetTargetingSpy).calledWithExactly('kv1', 'value');
-      expect(googletagPubAdsSetTargetingSpy).calledWithExactly('kv2', 'value');
-      expect(googletagPubAdsSetTargetingSpy).calledWithMatch('ABtest', Sinon.match.any);
+      expect(googletagSetConfigSpy.callCount).to.be.gte(4);
+      expect(googletagSetConfigSpy).calledWithMatch({ targeting: Sinon.match.has('keyFromAdConfig', 'value') });
+      expect(googletagSetConfigSpy).calledWithMatch({ targeting: Sinon.match.has('kv1', 'value') });
+      expect(googletagSetConfigSpy).calledWithMatch({ targeting: Sinon.match.has('kv2', 'value') });
+      expect(googletagSetConfigSpy).calledWithMatch({ targeting: Sinon.match.has('ABtest', Sinon.match.any) });
     });
   });
 

--- a/ad-tag/source/ts/ads/moli.test.ts
+++ b/ad-tag/source/ts/ads/moli.test.ts
@@ -1081,10 +1081,18 @@ describe('moli', () => {
       const spaState1: ISinglePageApp = state as ISinglePageApp;
       expect(spaState1.config).to.be.ok;
       expect(spaState1.nextRuntimeConfig.keyValues).to.be.deep.equal({});
-      expect(googletagSetConfigSpy).calledWithMatch({ targeting: Sinon.match.has('dynamicKeyValuePre', 'value') });
-      expect(googletagSetConfigSpy).calledWithMatch({ targeting: Sinon.match.has('dynamicKeyValuePost', 'value') });
-      expect(googletagSetConfigSpy).calledWithMatch({ targeting: Sinon.match.has('keyFromAdConfig', 'value') });
-      expect(googletagSetConfigSpy).calledWithMatch({ targeting: Sinon.match.has('ABtest', Sinon.match.any) });
+      expect(googletagSetConfigSpy).calledWithMatch({
+        targeting: Sinon.match.has('dynamicKeyValuePre', 'value')
+      });
+      expect(googletagSetConfigSpy).calledWithMatch({
+        targeting: Sinon.match.has('dynamicKeyValuePost', 'value')
+      });
+      expect(googletagSetConfigSpy).calledWithMatch({
+        targeting: Sinon.match.has('keyFromAdConfig', 'value')
+      });
+      expect(googletagSetConfigSpy).calledWithMatch({
+        targeting: Sinon.match.has('ABtest', Sinon.match.any)
+      });
 
       googletagSetConfigSpy.resetHistory();
       dom.reconfigure({
@@ -1113,10 +1121,14 @@ describe('moli', () => {
       expect(keyValues).to.not.have.property('dynamicKeyValuePost', 'value');
 
       expect(googletagSetConfigSpy.callCount).to.be.gte(4);
-      expect(googletagSetConfigSpy).calledWithMatch({ targeting: Sinon.match.has('keyFromAdConfig', 'value') });
+      expect(googletagSetConfigSpy).calledWithMatch({
+        targeting: Sinon.match.has('keyFromAdConfig', 'value')
+      });
       expect(googletagSetConfigSpy).calledWithMatch({ targeting: Sinon.match.has('kv1', 'value') });
       expect(googletagSetConfigSpy).calledWithMatch({ targeting: Sinon.match.has('kv2', 'value') });
-      expect(googletagSetConfigSpy).calledWithMatch({ targeting: Sinon.match.has('ABtest', Sinon.match.any) });
+      expect(googletagSetConfigSpy).calledWithMatch({
+        targeting: Sinon.match.has('ABtest', Sinon.match.any)
+      });
     });
   });
 

--- a/ad-tag/source/ts/stubs/googletagStubs.ts
+++ b/ad-tag/source/ts/stubs/googletagStubs.ts
@@ -7,13 +7,7 @@ const createPubAdsServiceStub = (): googletag.IPubAdsService => {
     set: (_key: string, _value: string): googletag.IPubAdsService => {
       return stub;
     },
-    setTargeting: (_key: string, _value: string | string[]): googletag.IPubAdsService => {
-      return stub;
-    },
     setRequestNonPersonalizedAds: (_value: 0 | 1): googletag.IPubAdsService => {
-      return stub;
-    },
-    clearTargeting: (_: string): googletag.IPubAdsService => {
       return stub;
     },
     refresh: (slots?: googletag.IAdSlot[], options?: { changeCorrelator: boolean }): void => {
@@ -55,14 +49,6 @@ export const googleAdSlotStub = (adUnitPath: string, slotId: string): googletag.
   let config: GptSlotSettingsConfig = {};
   let targetingMap: Record<string, string[]> = {};
   const stub: googletag.IAdSlot = {
-    clearTargeting(key?: string): void {
-      if (key) {
-        delete targetingMap[key];
-      } else {
-        targetingMap = {};
-      }
-      return;
-    },
     setTargeting: (key: string, value: string | string[]): googletag.IAdSlot => {
       if (typeof value === 'string') {
         targetingMap[key] = [value];
@@ -94,6 +80,19 @@ export const googleAdSlotStub = (adUnitPath: string, slotId: string): googletag.
     },
     setConfig(additionalConfig: googletag.GptSlotSettingsConfig) {
       config = { ...config, ...additionalConfig };
+      if (additionalConfig.targeting !== undefined) {
+        if (additionalConfig.targeting === null) {
+          targetingMap = {};
+        } else {
+          Object.entries(additionalConfig.targeting).forEach(([key, value]) => {
+            if (value === null) {
+              delete targetingMap[key];
+            } else {
+              targetingMap[key] = typeof value === 'string' ? [value] : value;
+            }
+          });
+        }
+      }
     },
     getConfig<T extends keyof GptSlotSettingsConfig>(
       key: T

--- a/ad-tag/source/ts/types/googletag.ts
+++ b/ad-tag/source/ts/types/googletag.ts
@@ -186,23 +186,6 @@ export namespace googletag {
     disableInitialLoad(): void;
 
     /**
-     * Sets custom targeting parameters for a given key that apply to all pubads service ad slots.
-     *
-     * Calling this multiple times for the same key will overwrite old values.
-     * These keys are defined in your DFP account.
-     *
-     * @param key Targeting parameter key.
-     * @param value Targeting parameter value or array of values.
-     */
-    setTargeting(key: string, value: string | Array<string>): IPubAdsService;
-
-    /**
-     * Clears custom targeting parameters for a specific key or for all keys.
-     * @param key Targeting parameter key. The key is optional; all targeting parameters will be cleared if it is unspecified.
-     */
-    clearTargeting(key?: string): IPubAdsService;
-
-    /**
      * Sets values for AdSense attributes that apply to all ad slots under the publisher ads service.
      *
      * See AdSense Attributes for a list of available keys and values.
@@ -813,8 +796,9 @@ export namespace googletag {
     /**
      * Setting to configure key-value targeting.
      * Targeting configured via this setting will only apply to the ad slot.
+     * Set a key's value to null to clear that key. Set targeting to null to clear all slot-level targeting.
      */
-    readonly targeting?: Record<string, string | string[]>;
+    readonly targeting?: Record<string, string | string[] | null> | null;
   }
 
   export namespace enums {
@@ -895,13 +879,6 @@ export namespace googletag {
      * @returns {string[]} Array of targeting keys. Ordering is undefined.
      */
     getTargetingKeys(): string[];
-
-    /**
-     * Clears specific or all custom slot-level targeting parameters for this slot.
-     * @param {string} key - optional key, if unspecified all slot targetings will be cleared
-     * @see https://developers.google.com/doubleclick-gpt/reference#googletag.Slot_clearTargeting
-     */
-    clearTargeting(key?: string): void;
 
     /**
      * Returns the ad response information. This is based on the last ad response for the slot.

--- a/schema.json
+++ b/schema.json
@@ -85,21 +85,31 @@
               "description": "Settings to configure the use of SafeFrame in GPT."
             },
             "targeting": {
-              "additionalProperties": {
-                "anyOf": [
-                  {
-                    "type": "string"
+              "anyOf": [
+                {
+                  "additionalProperties": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
                   },
-                  {
-                    "items": {
-                      "type": "string"
-                    },
-                    "type": "array"
-                  }
-                ]
-              },
-              "description": "Setting to configure key-value targeting. Targeting configured via this setting will only apply to the ad slot.",
-              "type": "object"
+                  "type": "object"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Setting to configure key-value targeting. Targeting configured via this setting will only apply to the ad slot. Set a key's value to null to clear that key. Set targeting to null to clear all slot-level targeting."
             }
           },
           "type": "object"


### PR DESCRIPTION
Those two methods are deprecated. See

* https://developers.google.com/publisher-tag/guides/publisher-console-messages#170
* https://developers.google.com/publisher-tag/guides/publisher-console-messages#171