### PR TITLE
Use minVisibleDurationMS even if trigger is in viewport on initial page load

### DIFF
--- a/ad-tag/source/ts/ads/modules/sticky-header-ad/adRenderResult.test.ts
+++ b/ad-tag/source/ts/ads/modules/sticky-header-ad/adRenderResult.test.ts
@@ -35,7 +35,7 @@ describe('renderResult', () => {
     ({
       env__: 'production',
       window__: jsDomWindow
-    } as AdPipelineContext);
+    }) as AdPipelineContext;
 
   afterEach(() => {
     dom = createDom();

--- a/ad-tag/source/ts/ads/modules/sticky-header-ad/adRenderResult.test.ts
+++ b/ad-tag/source/ts/ads/modules/sticky-header-ad/adRenderResult.test.ts
@@ -35,7 +35,7 @@ describe('renderResult', () => {
     ({
       env__: 'production',
       window__: jsDomWindow
-    }) as AdPipelineContext;
+    } as AdPipelineContext);
 
   afterEach(() => {
     dom = createDom();
@@ -49,172 +49,60 @@ describe('renderResult', () => {
 
   it('should resolve with standard if env is test', async () => {
     const ctx: AdPipelineContext = { ...adPipelineContext(), env__: 'test' };
-    const headerSlot = {
-      domId: domId
-    } as AdSlot;
+    const headerSlot = { domId: domId } as AdSlot;
     const disallowedAdvertiserIds = [1];
-    const minVisibleDuration = 0;
 
     const { adRenderResult } = await import('./renderResult');
-    const result = await adRenderResult(
-      ctx,
-      headerSlot,
-      disallowedAdvertiserIds,
-      minVisibleDuration
-    );
+    const result = await adRenderResult(ctx, headerSlot, disallowedAdvertiserIds);
 
     expect(result).to.equal('standard');
   });
 
   it('should do nothing if the dom id differs', async () => {
-    const headerSlot = {
-      domId: domId
-    } as AdSlot;
+    const headerSlot = { domId: domId } as AdSlot;
     const disallowedAdvertiserIds = [1];
-    const minVisibleDuration = 0;
 
-    resolveListenerWith({
-      slot: {
-        getSlotElementId: () => 'different'
-      }
-    } as any);
+    resolveListenerWith({ slot: { getSlotElementId: () => 'different' } } as any);
 
-    // wait a little bit to show that the other promise will be never resolved
     const sleep = new Promise<'unresolved'>(resolve =>
       setTimeout(() => resolve('unresolved'), 250)
     );
-
-    const result = adRenderResult(
-      adPipelineContext(),
-      headerSlot,
-      disallowedAdvertiserIds,
-      minVisibleDuration
-    );
-
+    const result = adRenderResult(adPipelineContext(), headerSlot, disallowedAdvertiserIds);
     const resolved = await Promise.race([result, sleep]);
 
     expect(resolved).to.equal('unresolved');
   });
 
   it('should resolve with empty if event is empty', async () => {
-    const headerSlot = {
-      domId: domId
-    } as AdSlot;
+    const headerSlot = { domId: domId } as AdSlot;
     const disallowedAdvertiserIds = [1];
-    const minVisibleDuration = 0;
 
-    resolveListenerWith({
-      slot: {
-        getSlotElementId: () => domId
-      },
-      isEmpty: true
-    } as any);
+    resolveListenerWith({ slot: { getSlotElementId: () => domId }, isEmpty: true } as any);
 
-    const result = await adRenderResult(
-      adPipelineContext(),
-      headerSlot,
-      disallowedAdvertiserIds,
-      minVisibleDuration
-    );
+    const result = await adRenderResult(adPipelineContext(), headerSlot, disallowedAdvertiserIds);
 
     expect(result).to.equal('empty');
   });
 
   it('should resolve with disallowed if advertiser id is in disallowed list', async () => {
-    const headerSlot = {
-      domId: domId
-    } as AdSlot;
+    const headerSlot = { domId: domId } as AdSlot;
     const disallowedAdvertiserIds = [1];
-    const minVisibleDuration = 0;
 
-    resolveListenerWith({
-      slot: {
-        getSlotElementId: () => domId
-      },
-      advertiserId: 1
-    } as any);
+    resolveListenerWith({ slot: { getSlotElementId: () => domId }, advertiserId: 1 } as any);
 
-    const result = await adRenderResult(
-      adPipelineContext(),
-      headerSlot,
-      disallowedAdvertiserIds,
-      minVisibleDuration
-    );
+    const result = await adRenderResult(adPipelineContext(), headerSlot, disallowedAdvertiserIds);
 
     expect(result).to.equal('disallowed');
   });
 
   it('should resolve with standard if advertiser id is not in disallowed list', async () => {
-    const headerSlot = {
-      domId: domId
-    } as AdSlot;
+    const headerSlot = { domId: domId } as AdSlot;
     const disallowedAdvertiserIds = [1];
-    const minVisibleDuration = 0;
 
-    resolveListenerWith({
-      slot: {
-        getSlotElementId: () => domId
-      },
-      advertiserId: 2
-    } as any);
+    resolveListenerWith({ slot: { getSlotElementId: () => domId }, advertiserId: 2 } as any);
 
-    const result = await adRenderResult(
-      adPipelineContext(),
-      headerSlot,
-      disallowedAdvertiserIds,
-      minVisibleDuration
-    );
+    const result = await adRenderResult(adPipelineContext(), headerSlot, disallowedAdvertiserIds);
 
-    expect(result).to.equal('standard');
-  });
-
-  it('should resolve with standard if minVisibleDuration is 0', async () => {
-    const headerSlot = {
-      domId: domId
-    } as AdSlot;
-    const disallowedAdvertiserIds = [1];
-    const minVisibleDuration = 0;
-
-    resolveListenerWith({
-      slot: {
-        getSlotElementId: () => domId
-      },
-      advertiserId: 2
-    } as any);
-
-    const result = await adRenderResult(
-      adPipelineContext(),
-      headerSlot,
-      disallowedAdvertiserIds,
-      minVisibleDuration
-    );
-
-    expect(result).to.equal('standard');
-  });
-
-  it('should resolve with standard after minVisibleDuration', async () => {
-    const setTimeSpy = sandbox.spy(jsDomWindow, 'setTimeout');
-    const headerSlot = {
-      domId: domId
-    } as AdSlot;
-    const disallowedAdvertiserIds = [1];
-    const minVisibleDuration = 100;
-
-    resolveListenerWith({
-      slot: {
-        getSlotElementId: () => domId
-      },
-      advertiserId: 2
-    } as any);
-
-    const result = await adRenderResult(
-      adPipelineContext(),
-      headerSlot,
-      disallowedAdvertiserIds,
-      minVisibleDuration
-    );
-
-    expect(setTimeSpy).to.have.been.calledWith(Sinon.match.func, minVisibleDuration);
     expect(result).to.equal('standard');
   });
 });

--- a/ad-tag/source/ts/ads/modules/sticky-header-ad/fadeOutCallback.test.ts
+++ b/ad-tag/source/ts/ads/modules/sticky-header-ad/fadeOutCallback.test.ts
@@ -29,6 +29,7 @@ describe('intersection observer fadeOut callback', () => {
    * @see https://stackoverflow.com/questions/44741102/how-to-make-jest-wait-for-all-asynchronous-code-to-finish-execution-before-expec
    */
   const waitForPromises = () => new Promise(process.nextTick);
+  const waitMs = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
 
   const createDiv = (id: string): HTMLDivElement => {
     const div = jsDomWindow.document.createElement('div');
@@ -70,7 +71,9 @@ describe('intersection observer fadeOut callback', () => {
       adRenderResultEmpty,
       null,
       null,
-      fadeOutClassName
+      fadeOutClassName,
+      0,
+      jsDomWindow
     )([], null as any);
 
     expect(container.classList.contains(fadeOutClassName)).to.be.false;
@@ -83,7 +86,9 @@ describe('intersection observer fadeOut callback', () => {
       adRenderResultEmpty,
       null,
       null,
-      fadeOutClassName
+      fadeOutClassName,
+      0,
+      jsDomWindow
     )([containerIntersectionEntry(container, true, 10)], null as any);
 
     expect(container.classList.contains(fadeOutClassName)).to.be.false;
@@ -96,7 +101,9 @@ describe('intersection observer fadeOut callback', () => {
       adRenderResultEmpty,
       null,
       null,
-      fadeOutClassName
+      fadeOutClassName,
+      0,
+      jsDomWindow
     )([containerIntersectionEntry(container, true, 10)], null as any);
     await waitForPromises();
 
@@ -133,7 +140,9 @@ describe('intersection observer fadeOut callback', () => {
           adRenderResult,
           null,
           null,
-          fadeOutClassName
+          fadeOutClassName,
+          0,
+          jsDomWindow
         )([entryWith(target)], null as any);
         await waitForPromises();
 
@@ -149,7 +158,9 @@ describe('intersection observer fadeOut callback', () => {
         adRenderResultStandard,
         null,
         null,
-        fadeOutClassName
+        fadeOutClassName,
+        0,
+        jsDomWindow
       )([containerIntersectionEntry(target, false, 10)], null as any);
       await waitForPromises();
 
@@ -178,7 +189,9 @@ describe('intersection observer fadeOut callback', () => {
           adRenderResultStandard,
           navbar,
           navbarHiddenClass,
-          fadeOutClassName
+          fadeOutClassName,
+          0,
+          jsDomWindow
         )([entryWith(navbar)], null as any);
 
         expect(container.classList.contains(navbarHiddenClass)).to.be.true;
@@ -193,10 +206,75 @@ describe('intersection observer fadeOut callback', () => {
         adRenderResultStandard,
         navbar,
         navbarHiddenClass,
-        fadeOutClassName
+        fadeOutClassName,
+        0,
+        jsDomWindow
       )([containerIntersectionEntry(navbar, true, 20)], null as any);
 
       expect(container.classList.contains(navbarHiddenClass)).to.be.false;
+    });
+  });
+
+  describe('minVisibleDurationMs', () => {
+    it('should suppress initial hide if trigger is in viewport on page load', async () => {
+      const minVisibleDurationMs = 50;
+      const callback = intersectionObserverFadeOutCallback(
+        container,
+        target,
+        adRenderResultStandard,
+        null,
+        null,
+        fadeOutClassName,
+        minVisibleDurationMs,
+        jsDomWindow
+      );
+
+      // initial intersection event fired by browser immediately on observe()
+      callback([containerIntersectionEntry(target, true, 20)], null as any);
+      await waitForPromises();
+
+      // should NOT be hidden yet — minVisibleDurationMs has not elapsed
+      expect(container.classList.contains(fadeOutClassName)).to.be.false;
+
+      // after the min visible period, a subsequent intersection should hide it
+      await waitMs(minVisibleDurationMs + 10);
+      callback([containerIntersectionEntry(target, true, 20)], null as any);
+      await waitForPromises();
+
+      expect(container.classList.contains(fadeOutClassName)).to.be.true;
+    });
+
+    it('should hide immediately if minVisibleDurationMs is 0', async () => {
+      intersectionObserverFadeOutCallback(
+        container,
+        target,
+        adRenderResultStandard,
+        null,
+        null,
+        fadeOutClassName,
+        0,
+        jsDomWindow
+      )([containerIntersectionEntry(target, true, 20)], null as any);
+      await waitForPromises();
+
+      expect(container.classList.contains(fadeOutClassName)).to.be.true;
+    });
+
+    it('should hide immediately for empty/disallowed even during minVisibleDurationMs', async () => {
+      const minVisibleDurationMs = 50;
+      intersectionObserverFadeOutCallback(
+        container,
+        target,
+        adRenderResultEmpty,
+        null,
+        null,
+        fadeOutClassName,
+        minVisibleDurationMs,
+        jsDomWindow
+      )([containerIntersectionEntry(target, true, 20)], null as any);
+      await waitForPromises();
+
+      expect(container.classList.contains(fadeOutClassName)).to.be.true;
     });
   });
 });

--- a/ad-tag/source/ts/ads/modules/sticky-header-ad/fadeOutCallback.ts
+++ b/ad-tag/source/ts/ads/modules/sticky-header-ad/fadeOutCallback.ts
@@ -11,66 +11,63 @@ import { RenderEventResult } from './renderResult';
  * @param minVisibleDurationMs
  * @param windowRef
  */
-export const intersectionObserverFadeOutCallback =
-  (
-    container: HTMLDivElement,
-    target: Element | null,
-    adRenderResult: Promise<RenderEventResult>,
-    navbar: Element | null,
-    navbarHiddenClass: string | null,
-    fadeOutClassName: string,
-    minVisibleDurationMs: number,
-    windowRef: Window
-  ): IntersectionObserverCallback => {
-    let canHide = minVisibleDurationMs <= 0;
-    let lastTargetEntry: IntersectionObserverEntry | null = null;
+export const intersectionObserverFadeOutCallback = (
+  container: HTMLDivElement,
+  target: Element | null,
+  adRenderResult: Promise<RenderEventResult>,
+  navbar: Element | null,
+  navbarHiddenClass: string | null,
+  fadeOutClassName: string,
+  minVisibleDurationMs: number,
+  windowRef: Window
+): IntersectionObserverCallback => {
+  let canHide = minVisibleDurationMs <= 0;
+  let lastTargetEntry: IntersectionObserverEntry | null = null;
 
-    const shouldFadeOut = (
-      entry: IntersectionObserverEntry,
-      result: RenderEventResult
-    ): boolean =>
-      result === 'empty' ||
-      result === 'disallowed' ||
-      (canHide && (entry.isIntersecting || (!entry.isIntersecting && entry.boundingClientRect.y < 0)));
+  const shouldFadeOut = (entry: IntersectionObserverEntry, result: RenderEventResult): boolean =>
+    result === 'empty' ||
+    result === 'disallowed' ||
+    (canHide &&
+      (entry.isIntersecting || (!entry.isIntersecting && entry.boundingClientRect.y < 0)));
 
-    const evaluateHide = (entry: IntersectionObserverEntry) => {
-      adRenderResult.then(result => {
-        if (shouldFadeOut(entry, result)) {
-          container.classList.add(fadeOutClassName);
-        } else if (entry.boundingClientRect.y >= 0 && result === 'standard') {
-          // if the ad should be visible again, because it's above the viewport and the ad is not empty and the
-          // advertiser is allowed, remove the fadeout class
-          container.classList.remove(fadeOutClassName);
-        }
-      });
-    };
-
-    if (!canHide) {
-      windowRef.setTimeout(() => {
-        canHide = true;
-        // If we have a pending intersection entry and ad is ready, evaluate hide now
-        if (lastTargetEntry) {
-          evaluateHide(lastTargetEntry);
-        }
-      }, minVisibleDurationMs);
-    }
-
-    return entries => {
-      // initially there maybe two events, for navbar and the target element
-      entries.forEach(entry => {
-        // fadeout the ad if the observed element is the target
-        if (target && entry.target === target) {
-          lastTargetEntry = entry;
-          // wait for the ad to be rendered before hiding it
-          evaluateHide(entry);
-        } else if (entry.target === navbar && navbarHiddenClass) {
-          // apply a separate class if the navbar is not intersecting the viewport anymore
-          if (entry.isIntersecting) {
-            container.classList.remove(navbarHiddenClass);
-          } else {
-            container.classList.add(navbarHiddenClass);
-          }
-        }
-      });
-    };
+  const evaluateHide = (entry: IntersectionObserverEntry) => {
+    adRenderResult.then(result => {
+      if (shouldFadeOut(entry, result)) {
+        container.classList.add(fadeOutClassName);
+      } else if (entry.boundingClientRect.y >= 0 && result === 'standard') {
+        // if the ad should be visible again, because it's above the viewport and the ad is not empty and the
+        // advertiser is allowed, remove the fadeout class
+        container.classList.remove(fadeOutClassName);
+      }
+    });
   };
+
+  if (!canHide) {
+    windowRef.setTimeout(() => {
+      canHide = true;
+      // If we have a pending intersection entry and ad is ready, evaluate hide now
+      if (lastTargetEntry) {
+        evaluateHide(lastTargetEntry);
+      }
+    }, minVisibleDurationMs);
+  }
+
+  return entries => {
+    // initially there maybe two events, for navbar and the target element
+    entries.forEach(entry => {
+      // fadeout the ad if the observed element is the target
+      if (target && entry.target === target) {
+        lastTargetEntry = entry;
+        // wait for the ad to be rendered before hiding it
+        evaluateHide(entry);
+      } else if (entry.target === navbar && navbarHiddenClass) {
+        // apply a separate class if the navbar is not intersecting the viewport anymore
+        if (entry.isIntersecting) {
+          container.classList.remove(navbarHiddenClass);
+        } else {
+          container.classList.add(navbarHiddenClass);
+        }
+      }
+    });
+  };
+};

--- a/ad-tag/source/ts/ads/modules/sticky-header-ad/fadeOutCallback.ts
+++ b/ad-tag/source/ts/ads/modules/sticky-header-ad/fadeOutCallback.ts
@@ -8,6 +8,8 @@ import { RenderEventResult } from './renderResult';
  * @param navbar
  * @param navbarHiddenClass
  * @param fadeOutClassName
+ * @param minVisibleDurationMs
+ * @param windowRef
  */
 export const intersectionObserverFadeOutCallback =
   (
@@ -16,38 +18,59 @@ export const intersectionObserverFadeOutCallback =
     adRenderResult: Promise<RenderEventResult>,
     navbar: Element | null,
     navbarHiddenClass: string | null,
-    fadeOutClassName: string
-  ): IntersectionObserverCallback =>
-  entries => {
-    // initially there maybe two events, for navbar and the target element
-    entries.forEach(entry => {
-      // fadeout the ad if the observed element is the target
-      if (target && entry.target === target) {
-        // wait for the ad to be rendered before hiding it
-        adRenderResult.then(result => {
-          if (
-            // user scrolls down
-            entry.isIntersecting ||
-            // user starts below observed DOM
-            (!entry.isIntersecting && entry.boundingClientRect.y < 0) ||
-            // if the ad is empty or an advertiser which is not allowed for this format, hide it
-            result === 'empty' ||
-            result === 'disallowed'
-          ) {
-            container.classList.add(fadeOutClassName);
-          } else if (entry.boundingClientRect.y >= 0 && result === 'standard') {
-            // if the ad should be visible again, because it's above the viewport and the ad is not empty and the
-            // advertiser is allowed, remove the fadeout class
-            container.classList.remove(fadeOutClassName);
-          }
-        });
-      } else if (entry.target === navbar && navbarHiddenClass) {
-        // apply a separate class if the navbar is not intersecting the viewport anymore
-        if (entry.isIntersecting) {
-          container.classList.remove(navbarHiddenClass);
-        } else {
-          container.classList.add(navbarHiddenClass);
+    fadeOutClassName: string,
+    minVisibleDurationMs: number,
+    windowRef: Window
+  ): IntersectionObserverCallback => {
+    let canHide = minVisibleDurationMs <= 0;
+    let lastTargetEntry: IntersectionObserverEntry | null = null;
+
+    const shouldFadeOut = (
+      entry: IntersectionObserverEntry,
+      result: RenderEventResult
+    ): boolean =>
+      result === 'empty' ||
+      result === 'disallowed' ||
+      (canHide && (entry.isIntersecting || (!entry.isIntersecting && entry.boundingClientRect.y < 0)));
+
+    const evaluateHide = (entry: IntersectionObserverEntry) => {
+      adRenderResult.then(result => {
+        if (shouldFadeOut(entry, result)) {
+          container.classList.add(fadeOutClassName);
+        } else if (entry.boundingClientRect.y >= 0 && result === 'standard') {
+          // if the ad should be visible again, because it's above the viewport and the ad is not empty and the
+          // advertiser is allowed, remove the fadeout class
+          container.classList.remove(fadeOutClassName);
         }
-      }
-    });
+      });
+    };
+
+    if (!canHide) {
+      windowRef.setTimeout(() => {
+        canHide = true;
+        // If we have a pending intersection entry and ad is ready, evaluate hide now
+        if (lastTargetEntry) {
+          evaluateHide(lastTargetEntry);
+        }
+      }, minVisibleDurationMs);
+    }
+
+    return entries => {
+      // initially there maybe two events, for navbar and the target element
+      entries.forEach(entry => {
+        // fadeout the ad if the observed element is the target
+        if (target && entry.target === target) {
+          lastTargetEntry = entry;
+          // wait for the ad to be rendered before hiding it
+          evaluateHide(entry);
+        } else if (entry.target === navbar && navbarHiddenClass) {
+          // apply a separate class if the navbar is not intersecting the viewport anymore
+          if (entry.isIntersecting) {
+            container.classList.remove(navbarHiddenClass);
+          } else {
+            container.classList.add(navbarHiddenClass);
+          }
+        }
+      });
+    };
   };

--- a/ad-tag/source/ts/ads/modules/sticky-header-ad/index.ts
+++ b/ad-tag/source/ts/ads/modules/sticky-header-ad/index.ts
@@ -169,8 +169,7 @@ export const createStickyHeaderAd = (): IModule => {
                 const adRenderResultPromise = adRenderResult(
                   ctx,
                   headerSlot.moliSlot,
-                  config.disallowedAdvertiserIds,
-                  minVisibleDuration
+                  config.disallowedAdvertiserIds
                 );
 
                 // setup intersection observer
@@ -181,7 +180,9 @@ export const createStickyHeaderAd = (): IModule => {
                     adRenderResultPromise,
                     navbar,
                     navbarHiddenClass,
-                    config.fadeOutClassName
+                    config.fadeOutClassName,
+                    minVisibleDuration,
+                    ctx.window__
                   ),
                   options
                 );

--- a/ad-tag/source/ts/ads/modules/sticky-header-ad/renderResult.ts
+++ b/ad-tag/source/ts/ads/modules/sticky-header-ad/renderResult.ts
@@ -13,8 +13,7 @@ export type RenderEventResult = 'empty' | 'disallowed' | 'standard';
 export const adRenderResult = (
   ctx: AdPipelineContext,
   headerSlot: AdSlot,
-  disallowedAdvertiserIds: number[],
-  minVisibleDuration: number
+  disallowedAdvertiserIds: number[]
 ) =>
   new Promise<RenderEventResult>(resolve => {
     // in test mode there's no event fired so we need to resolve immediately and say it's not empty
@@ -34,9 +33,7 @@ export const adRenderResult = (
       } else if (event.isEmpty) {
         resolve('empty');
       } else {
-        minVisibleDuration > 0
-          ? ctx.window__.setTimeout(() => resolve('standard'), minVisibleDuration)
-          : resolve('standard');
+        resolve('standard');
       }
       ctx.window__.googletag.pubads().removeEventListener('slotRenderEnded', listener);
     };


### PR DESCRIPTION
We realized that the sticky header is never visible if the ad slot trigger that is supposed to hide the container is in the viewport on initial page load. This happens e.g. on larger phone sizes on gutefrage.net.

Even if I set a minVisibleDurationMs configuration, the header does not appear. The IntersectionObserver fires immediately on observe() with the current viewport state. If the fade-out trigger element is in the viewport on initial load, the callback fires with entry.isIntersecting = true before the ad even renders. 

Goal of this PR: Always show the sticky header for the given time frame in the minVisibleDurationMs setting.