### PR TITLE
Add additional tcfStorage control fields

### DIFF
--- a/ad-tag/source/ts/types/prebidjs.ts
+++ b/ad-tag/source/ts/types/prebidjs.ts
@@ -540,9 +540,10 @@ export namespace prebidjs {
        * Supported values:
        * - "storage" (Purpose 1)
        * - "basicAds" (Purpose 2)
+       * - "personalizedAds" (Purpose 4)
        * - "measurement" (Purpose 7)
        */
-      readonly purpose: 'storage' | 'basicAds' | 'measurement';
+      readonly purpose: 'storage' | 'basicAds' | 'measurement' | 'personalizedAds';
 
       /**
        * Determines whether to enforce the purpose consent or not. The default in Prebid.js 3.x is not to enforce
@@ -582,6 +583,13 @@ export namespace prebidjs {
        * ```
        */
       readonly softVendorExceptions?: string[];
+
+      /**
+       * If true, allows s2s bidders to bypass vendor consent check and delegate it to server.
+       * Applies only to basicAds rule.
+       * @default false
+       */
+      readonly deferS2Sbidders?: boolean;
     }
   }
 

--- a/schema.json
+++ b/schema.json
@@ -11132,7 +11132,7 @@
         "rules": {
           "description": "`Rules` is an array of objects that a publisher can construct to provide fine-grained control over a given activity. For instance, you could set up a series of rules that says:\n\n- Amongst the bid adapters, BidderA is always allowed to receive user first-party data\n- Always let analytics adapters receive user first-party data\n- Otherwise, let the active privacy modules decide\n- if they refuse to decide, then the overall default is to allow the transmitting of user first-party data",
           "items": {
-            "$ref": "#/definitions/prebidjs.activitycontrols.IActivityRule%3Cstructure-248365657-208815-208818-248365657-208808-208818-248365657-208776-209604-248365657-206683-212786-248365657-206568-212786-248365657-195-221851-248365657-168-221851-248365657-0-221852%3E"
+            "$ref": "#/definitions/prebidjs.activitycontrols.IActivityRule%3Cstructure-248365657-209098-209101-248365657-209091-209101-248365657-209059-209887-248365657-206966-213069-248365657-206851-213069-248365657-195-222134-248365657-168-222134-248365657-0-222135%3E"
           },
           "type": "array"
         }
@@ -11142,7 +11142,7 @@
       ],
       "type": "object"
     },
-    "prebidjs.activitycontrols.IActivity<(alias-248365657-207719-207889-248365657-206683-212786-248365657-206568-212786-248365657-195-221851-248365657-168-221851-248365657-0-2218521149092559&alias-248365657-207889-208022-248365657-206683-212786-248365657-206568-212786-248365657-195-221851-248365657-168-221851-248365657-0-2218521210238678)>": {
+    "prebidjs.activitycontrols.IActivity<(alias-248365657-208002-208172-248365657-206966-213069-248365657-206851-213069-248365657-195-222134-248365657-168-222134-248365657-0-2221351149092559&alias-248365657-208172-208305-248365657-206966-213069-248365657-206851-213069-248365657-195-222134-248365657-168-222134-248365657-0-2221351210238678)>": {
       "additionalProperties": false,
       "properties": {
         "default": {
@@ -11152,7 +11152,7 @@
         "rules": {
           "description": "`Rules` is an array of objects that a publisher can construct to provide fine-grained control over a given activity. For instance, you could set up a series of rules that says:\n\n- Amongst the bid adapters, BidderA is always allowed to receive user first-party data\n- Always let analytics adapters receive user first-party data\n- Otherwise, let the active privacy modules decide\n- if they refuse to decide, then the overall default is to allow the transmitting of user first-party data",
           "items": {
-            "$ref": "#/definitions/prebidjs.activitycontrols.IActivityRule%3C(alias-248365657-207719-207889-248365657-206683-212786-248365657-206568-212786-248365657-195-221851-248365657-168-221851-248365657-0-2218521149092559%26alias-248365657-207889-208022-248365657-206683-212786-248365657-206568-212786-248365657-195-221851-248365657-168-221851-248365657-0-2218521210238678)%3E"
+            "$ref": "#/definitions/prebidjs.activitycontrols.IActivityRule%3C(alias-248365657-208002-208172-248365657-206966-213069-248365657-206851-213069-248365657-195-222134-248365657-168-222134-248365657-0-2221351149092559%26alias-248365657-208172-208305-248365657-206966-213069-248365657-206851-213069-248365657-195-222134-248365657-168-222134-248365657-0-2221351210238678)%3E"
           },
           "type": "array"
         }
@@ -11162,7 +11162,7 @@
       ],
       "type": "object"
     },
-    "prebidjs.activitycontrols.IActivity<alias-248365657-207264-207478-248365657-206683-212786-248365657-206568-212786-248365657-195-221851-248365657-168-221851-248365657-0-22185298888365>": {
+    "prebidjs.activitycontrols.IActivity<alias-248365657-207547-207761-248365657-206966-213069-248365657-206851-213069-248365657-195-222134-248365657-168-222134-248365657-0-22213598888365>": {
       "additionalProperties": false,
       "properties": {
         "default": {
@@ -11172,7 +11172,7 @@
         "rules": {
           "description": "`Rules` is an array of objects that a publisher can construct to provide fine-grained control over a given activity. For instance, you could set up a series of rules that says:\n\n- Amongst the bid adapters, BidderA is always allowed to receive user first-party data\n- Always let analytics adapters receive user first-party data\n- Otherwise, let the active privacy modules decide\n- if they refuse to decide, then the overall default is to allow the transmitting of user first-party data",
           "items": {
-            "$ref": "#/definitions/prebidjs.activitycontrols.IActivityRule%3Calias-248365657-207264-207478-248365657-206683-212786-248365657-206568-212786-248365657-195-221851-248365657-168-221851-248365657-0-22185298888365%3E"
+            "$ref": "#/definitions/prebidjs.activitycontrols.IActivityRule%3Calias-248365657-207547-207761-248365657-206966-213069-248365657-206851-213069-248365657-195-222134-248365657-168-222134-248365657-0-22213598888365%3E"
           },
           "type": "array"
         }
@@ -11182,7 +11182,7 @@
       ],
       "type": "object"
     },
-    "prebidjs.activitycontrols.IActivity<alias-248365657-207478-207719-248365657-206683-212786-248365657-206568-212786-248365657-195-221851-248365657-168-221851-248365657-0-221852187177090>": {
+    "prebidjs.activitycontrols.IActivity<alias-248365657-207761-208002-248365657-206966-213069-248365657-206851-213069-248365657-195-222134-248365657-168-222134-248365657-0-222135187177090>": {
       "additionalProperties": false,
       "properties": {
         "default": {
@@ -11192,7 +11192,7 @@
         "rules": {
           "description": "`Rules` is an array of objects that a publisher can construct to provide fine-grained control over a given activity. For instance, you could set up a series of rules that says:\n\n- Amongst the bid adapters, BidderA is always allowed to receive user first-party data\n- Always let analytics adapters receive user first-party data\n- Otherwise, let the active privacy modules decide\n- if they refuse to decide, then the overall default is to allow the transmitting of user first-party data",
           "items": {
-            "$ref": "#/definitions/prebidjs.activitycontrols.IActivityRule%3Calias-248365657-207478-207719-248365657-206683-212786-248365657-206568-212786-248365657-195-221851-248365657-168-221851-248365657-0-221852187177090%3E"
+            "$ref": "#/definitions/prebidjs.activitycontrols.IActivityRule%3Calias-248365657-207761-208002-248365657-206966-213069-248365657-206851-213069-248365657-195-222134-248365657-168-222134-248365657-0-222135187177090%3E"
           },
           "type": "array"
         }
@@ -11202,7 +11202,7 @@
       ],
       "type": "object"
     },
-    "prebidjs.activitycontrols.IActivityRule<(alias-248365657-207719-207889-248365657-206683-212786-248365657-206568-212786-248365657-195-221851-248365657-168-221851-248365657-0-2218521149092559&alias-248365657-207889-208022-248365657-206683-212786-248365657-206568-212786-248365657-195-221851-248365657-168-221851-248365657-0-2218521210238678)>": {
+    "prebidjs.activitycontrols.IActivityRule<(alias-248365657-208002-208172-248365657-206966-213069-248365657-206851-213069-248365657-195-222134-248365657-168-222134-248365657-0-2221351149092559&alias-248365657-208172-208305-248365657-206966-213069-248365657-206851-213069-248365657-195-222134-248365657-168-222134-248365657-0-2221351210238678)>": {
       "additionalProperties": false,
       "properties": {
         "allow": {
@@ -11265,7 +11265,7 @@
       },
       "type": "object"
     },
-    "prebidjs.activitycontrols.IActivityRule<alias-248365657-207264-207478-248365657-206683-212786-248365657-206568-212786-248365657-195-221851-248365657-168-221851-248365657-0-22185298888365>": {
+    "prebidjs.activitycontrols.IActivityRule<alias-248365657-207547-207761-248365657-206966-213069-248365657-206851-213069-248365657-195-222134-248365657-168-222134-248365657-0-22213598888365>": {
       "additionalProperties": false,
       "properties": {
         "allow": {
@@ -11325,7 +11325,7 @@
       },
       "type": "object"
     },
-    "prebidjs.activitycontrols.IActivityRule<alias-248365657-207478-207719-248365657-206683-212786-248365657-206568-212786-248365657-195-221851-248365657-168-221851-248365657-0-221852187177090>": {
+    "prebidjs.activitycontrols.IActivityRule<alias-248365657-207761-208002-248365657-206966-213069-248365657-206851-213069-248365657-195-222134-248365657-168-222134-248365657-0-222135187177090>": {
       "additionalProperties": false,
       "properties": {
         "allow": {
@@ -11380,7 +11380,7 @@
       },
       "type": "object"
     },
-    "prebidjs.activitycontrols.IActivityRule<structure-248365657-208815-208818-248365657-208808-208818-248365657-208776-209604-248365657-206683-212786-248365657-206568-212786-248365657-195-221851-248365657-168-221851-248365657-0-221852>": {
+    "prebidjs.activitycontrols.IActivityRule<structure-248365657-209098-209101-248365657-209091-209101-248365657-209059-209887-248365657-206966-213069-248365657-206851-213069-248365657-195-222134-248365657-168-222134-248365657-0-222135>": {
       "additionalProperties": false,
       "properties": {
         "allow": {
@@ -11436,7 +11436,7 @@
       "description": "Starting with version 7.52, Prebid.js introduced a centralized control mechanism for privacy-sensitive activities\n- such as accessing device storage or sharing data with partners.  These controls are intended to serve as building blocks for privacy protection mechanisms, allowing module developers or publishers to directly specify what should be permitted or avoided in any given regulatory environment.",
       "properties": {
         "accessDevice": {
-          "$ref": "#/definitions/prebidjs.activitycontrols.IActivity%3Calias-248365657-207264-207478-248365657-206683-212786-248365657-206568-212786-248365657-195-221851-248365657-168-221851-248365657-0-22185298888365%3E",
+          "$ref": "#/definitions/prebidjs.activitycontrols.IActivity%3Calias-248365657-207547-207761-248365657-206966-213069-248365657-206851-213069-248365657-195-222134-248365657-168-222134-248365657-0-22213598888365%3E",
           "description": "A component wants to use device storage.\n\nEffect when denied: Storage is disabled"
         },
         "enrichEids": {
@@ -11448,7 +11448,7 @@
           "description": "A Real-Time Data (RTD) submodule wants to add user first-party data to outgoing requests (`user.data` in ORTB)\n\nEffect when denied: User FPD is discarded"
         },
         "fetchBids": {
-          "$ref": "#/definitions/prebidjs.activitycontrols.IActivity%3Calias-248365657-207478-207719-248365657-206683-212786-248365657-206568-212786-248365657-195-221851-248365657-168-221851-248365657-0-221852187177090%3E",
+          "$ref": "#/definitions/prebidjs.activitycontrols.IActivity%3Calias-248365657-207761-208002-248365657-206966-213069-248365657-206851-213069-248365657-195-222134-248365657-168-222134-248365657-0-222135187177090%3E",
           "description": "A bid adapter wants to participate in an auction\n\nEffect when denied: Bidder is removed from the auction"
         },
         "reportAnalytics": {
@@ -11456,23 +11456,23 @@
           "description": "An analytics adapter is being enabled through `pbjs.enableAnalytics`\n\nEffect when denied: Adapter remains disabled"
         },
         "syncUser": {
-          "$ref": "#/definitions/prebidjs.activitycontrols.IActivity%3C(alias-248365657-207719-207889-248365657-206683-212786-248365657-206568-212786-248365657-195-221851-248365657-168-221851-248365657-0-2218521149092559%26alias-248365657-207889-208022-248365657-206683-212786-248365657-206568-212786-248365657-195-221851-248365657-168-221851-248365657-0-2218521210238678)%3E",
+          "$ref": "#/definitions/prebidjs.activitycontrols.IActivity%3C(alias-248365657-208002-208172-248365657-206966-213069-248365657-206851-213069-248365657-195-222134-248365657-168-222134-248365657-0-2221351149092559%26alias-248365657-208172-208305-248365657-206966-213069-248365657-206851-213069-248365657-195-222134-248365657-168-222134-248365657-0-2221351210238678)%3E",
           "description": "A bid adapter wants to fetch a [user sync](https://docs.prebid.org/dev-docs/publisher-api-reference/setConfig.html#setConfig-Configure-User-Syncing)\n\nEffect when denied: User sync is skipped"
         },
         "transmitEids": {
-          "$ref": "#/definitions/prebidjs.activitycontrols.IActivity%3Calias-248365657-207478-207719-248365657-206683-212786-248365657-206568-212786-248365657-195-221851-248365657-168-221851-248365657-0-221852187177090%3E",
+          "$ref": "#/definitions/prebidjs.activitycontrols.IActivity%3Calias-248365657-207761-208002-248365657-206966-213069-248365657-206851-213069-248365657-195-222134-248365657-168-222134-248365657-0-222135187177090%3E",
           "description": "A bid adapter or RTD submodule wants to access and/or transmit user IDs to their endpoint.\n\nEffect when denied: User IDs are hidden from the component"
         },
         "transmitPreciseGeo": {
-          "$ref": "#/definitions/prebidjs.activitycontrols.IActivity%3Calias-248365657-207478-207719-248365657-206683-212786-248365657-206568-212786-248365657-195-221851-248365657-168-221851-248365657-0-221852187177090%3E",
+          "$ref": "#/definitions/prebidjs.activitycontrols.IActivity%3Calias-248365657-207761-208002-248365657-206966-213069-248365657-206851-213069-248365657-195-222134-248365657-168-222134-248365657-0-222135187177090%3E",
           "description": "A bid adapter or RTD submodule wants to access and/or transmit precise geolocation data to their endpoint.\n\nEffect when denied: Component is allowed only 2-digit precision for latitude and longitude"
         },
         "transmitTid": {
-          "$ref": "#/definitions/prebidjs.activitycontrols.IActivity%3Calias-248365657-207478-207719-248365657-206683-212786-248365657-206568-212786-248365657-195-221851-248365657-168-221851-248365657-0-221852187177090%3E",
+          "$ref": "#/definitions/prebidjs.activitycontrols.IActivity%3Calias-248365657-207761-208002-248365657-206966-213069-248365657-206851-213069-248365657-195-222134-248365657-168-222134-248365657-0-222135187177090%3E",
           "description": "A bid adapter or RTD submodule wants to access and/or transmit globally unique transaction IDs to their endpoint.\n\nEffect when denied: Transaction IDs are hidden from the component"
         },
         "transmitUfpd": {
-          "$ref": "#/definitions/prebidjs.activitycontrols.IActivity%3Calias-248365657-207478-207719-248365657-206683-212786-248365657-206568-212786-248365657-195-221851-248365657-168-221851-248365657-0-221852187177090%3E",
+          "$ref": "#/definitions/prebidjs.activitycontrols.IActivity%3Calias-248365657-207761-208002-248365657-206966-213069-248365657-206851-213069-248365657-195-222134-248365657-168-222134-248365657-0-222135187177090%3E",
           "description": "A bid adapter or RTD submodule wants to access and/or transmit user FPD to their endpoint.\n\nEffect when denied: User FPD is hidden from the component"
         }
       },
@@ -12154,6 +12154,11 @@
     "prebidjs.consent.IGdprConfigRule": {
       "additionalProperties": false,
       "properties": {
+        "deferS2Sbidders": {
+          "default": false,
+          "description": "If true, allows s2s bidders to bypass vendor consent check and delegate it to server. Applies only to basicAds rule.",
+          "type": "boolean"
+        },
         "enforcePurpose": {
           "description": "Determines whether to enforce the purpose consent or not. The default in Prebid.js 3.x is not to enforce purposes. The plan for Prebid.js 4.0 is to enforce consent for Purpose 1 and no others.",
           "type": "boolean"
@@ -12163,11 +12168,12 @@
           "type": "boolean"
         },
         "purpose": {
-          "description": "Supported values:\n- \"storage\" (Purpose 1)\n- \"basicAds\" (Purpose 2)\n- \"measurement\" (Purpose 7)",
+          "description": "Supported values:\n- \"storage\" (Purpose 1)\n- \"basicAds\" (Purpose 2)\n- \"personalizedAds\" (Purpose 4)\n- \"measurement\" (Purpose 7)",
           "enum": [
             "storage",
             "basicAds",
-            "measurement"
+            "measurement",
+            "personalizedAds"
           ],
           "type": "string"
         },


### PR DESCRIPTION
If true, allows s2s bidders to bypass vendor consent check and delegate it to server. Applies only to basicAds rule. Defaults to false